### PR TITLE
Remove clusterIP None

### DIFF
--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
 spec:
-  clusterIP: None
   ports:
   - name: admin-3000
     port: 3000

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
 spec:
-  clusterIP: None
   ports:
   - name: api-8000
     port: 8000

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
 spec:
-  clusterIP: None
   ports:
   - name: minio-api-9000
     port: 9000

--- a/charts/plane-ce/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/postgres.stateful.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
 spec:
-  clusterIP: None
   ports:
   - name: pg-{{ .Values.postgres.servicePort }}
     port: {{ .Values.postgres.servicePort }}

--- a/charts/plane-ce/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/redis.stateful.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
 spec:
-  clusterIP: None
   ports:
   - name: redis-{{ .Values.redis.servicePort }}
     port: {{ .Values.redis.servicePort }}

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
 spec:
-  clusterIP: None
   ports:
   - name: space-3000
     port: 3000

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
 spec:
-  clusterIP: None
   ports:
   - name: web-3000
     port: 3000

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
 spec:
-  clusterIP: None
   ports:
   - name: admin-3000
     port: 3000

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
 spec:
-  clusterIP: None
   ports:
   - name: api-8000
     port: 8000

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
 spec:
-  clusterIP: None
   ports:
   - name: minio-api-9000
     port: 9000

--- a/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
 spec:
-  clusterIP: None
   ports:
   - name: pg-{{ .Values.services.postgres.servicePort }}
     port: {{ .Values.services.postgres.servicePort }}

--- a/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
 spec:
-  clusterIP: None
   ports:
   - name: redis-{{ .Values.services.redis.servicePort }}
     port: {{ .Values.services.redis.servicePort }}

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
 spec:
-  clusterIP: None
   ports:
   - name: space-3000
     port: 3000

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
 spec:
-  clusterIP: None
   ports:
   - name: web-3000
     port: 3000


### PR DESCRIPTION
Just who thinks this is a good idea...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transitioned several services from headless configurations to standard ClusterIP services, enhancing accessibility and allowing for improved load balancing and service discovery within the Kubernetes cluster.
  
- **Bug Fixes**
  - Corrected service types for multiple deployments, ensuring expected routing and communication patterns for applications interacting with these services.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->