### PR TITLE
Postgres version update and minio client image add in values file

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.0.24
+version: 1.0.25
 appVersion: "0.22.0"
 
 home: https://plane.so

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -366,6 +366,11 @@ questions:
     type: string
     default: "minio/minio:latest"
     show_if: "minio.local_setup=true"
+  - variable: minio.image_mc
+    label: "MinIO Client Docker Image"
+    type: string
+    default: "minio/mc:latest"
+    show_if: "minio.local_setup=true"
   - variable: minio.root_user
     label: "Root User"
     type: string

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -115,7 +115,7 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-doc-store-secrets
                 optional: false
-          image: minio/mc
+          image: {{ .Values.minio.image_mc }}
           imagePullPolicy: {{ .Values.minio.pullPolicy }}
           name: {{ .Release.Name }}-minio-bucket
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -36,7 +36,7 @@ redis:
 
 postgres:
   local_setup: true
-  image: postgres:15.5-alpine
+  image: postgres:15.7-alpine
   servicePort: 5432
   cliConnectPort: ""
   storageClass: longhorn
@@ -59,6 +59,7 @@ rabbitmq:
 
 minio:
   image: minio/minio:latest
+  image_mc: minio/mc:latest
   local_setup: true
   pullPolicy: IfNotPresent
   root_password: password

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.0.12
+version: 1.0.13
 appVersion: "1.3.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -389,6 +389,11 @@ questions:
     type: string
     default: "registry.plane.tools/plane/minio:latest"
     show_if: "services.minio.local_setup=true"
+  - variable: services.minio.image_mc
+    label: "MinIO Client Docker Image"
+    type: string
+    default: "minio/mc:latest"
+    show_if: "services.minio.local_setup=true"
   - variable: services.minio.root_user
     label: "Root User"
     type: string

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -115,7 +115,7 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-doc-store-secrets
                 optional: false
-          image: minio/mc
+          image: {{ .Values.services.minio.image_mc }}
           imagePullPolicy: Always
           name: {{ .Release.Name }}-minio-bucket
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -37,7 +37,7 @@ services:
 
   postgres:
     local_setup: true
-    image: registry.plane.tools/plane/postgres:15.5-alpine
+    image: registry.plane.tools/plane/postgres:15.7-alpine
     servicePort: 5432
     cliConnectPort: ''
     volumeSize: 2Gi
@@ -57,6 +57,7 @@ services:
   minio:
     local_setup: true
     image: registry.plane.tools/plane/minio:latest
+    image_mc: minio/mc:latest
     volumeSize: 3Gi
     root_user: admin
     root_password: password


### PR DESCRIPTION
Changes: 
PG Version - v15.7-alpine
MinIO Client image using `values.yml` file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for specifying the MinIO Client Docker image.
	- Enhanced conditional visibility for various configuration options based on local setup.
- **Bug Fixes**
	- Corrected YAML formatting for improved readability and structure.
- **Updates**
	- Incremented version numbers for both `plane-ce` and `plane-enterprise` applications.
	- Updated PostgreSQL image version from `15.5-alpine` to `15.7-alpine`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->