### PR TITLE
Plane CE live service 

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.0.24
+version: 1.0.25
 appVersion: "0.22.0"
 
 home: https://plane.so

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -146,6 +146,19 @@
 | admin.image| makeplane/plane-admin |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | admin.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
 
+### Live Service Deployment
+
+| Setting | Default | Required | Description |
+|---|:---:|:---:|---|
+| live.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
+| live.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
+| live.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| live.image| makeplane/plane-live |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| env.live_sentry_dsn |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
+| env.live_sentry_environment |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
+| env.live_sentry_traces_sample_rate |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry trace sample rate (as configured in Sentry) for this integration.|
+| live.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+
 ### API Deployment
 
 | Setting | Default | Required | Description |

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -125,7 +125,7 @@ questions:
   type: string
   required: true
   default: "makeplane/plane-live"
-  description: "Used by API, Worker, Beat-Worker"
+  description: "Live Server Setup"
   group: "Live Setup"
   subquestions:
   - variable: live.pullPolicy

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -120,6 +120,52 @@ questions:
     type: boolean
     default: true
 
+- variable: live.image
+  label: Live Docker Image
+  type: string
+  required: true
+  default: "makeplane/plane-live"
+  description: "Used by API, Worker, Beat-Worker"
+  group: "Live Setup"
+  subquestions:
+  - variable: live.pullPolicy
+    label: "Image Pull Policy"
+    type: enum
+    options:
+      - "Always"
+      - "IfNotPresent"
+      - "Never"
+    default: "IfNotPresent"
+  - variable: live.replicas
+    label: "Default Replica Count"
+    type: int
+    default: 1
+  - variable: live.memoryLimit
+    label: "Memory Limit"
+    type: string
+    default: 1000Mi
+  - variable: live.cpuLimit
+    label: "CPU Limit"
+    type: string
+    default: 500m
+  - variable: live.assign_cluster_ip
+    label: "Assign Cluster IP"
+    type: boolean
+    default: false
+  
+  - variable: env.live_sentry_dsn
+    label: "Live Sentry DSN"
+    type: string
+    default: ""
+  - variable: env.live_sentry_environment
+    label: "Live Sentry Environment"
+    type: string
+    default: ""
+  - variable: env.live_sentry_traces_sample_rate
+    label: "Live Sentry Traces Sample Rate"
+    type: string
+    default: ""
+
 - variable: api.image
   label: Backend Docker Image
   type: string

--- a/charts/plane-ce/templates/config-secrets/live-env.yaml
+++ b/charts/plane-ce/templates/config-secrets/live-env.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-live-vars
+data:
+  API_BASE_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/"
+  LIVE_SENTRY_DSN: {{ .Values.env.live_sentry_dsn | default "" | quote }}
+  LIVE_SENTRY_ENVIRONMENT: {{ .Values.env.live_sentry_environment | default "" | quote }}
+  LIVE_SENTRY_TRACES_SAMPLE_RATE: {{ .Values.env.live_sentry_traces_sample_rate | default "" | quote }}
+  LIVE_BASE_PATH: "/live"
+
+  {{- if .Values.services.redis.local_setup }}
+  REDIS_URL: "redis://{{ .Release.Name }}-redis.{{ .Release.Namespace }}.svc.cluster.local:6379/"
+  {{- else }}
+  REDIS_URL: {{ .Values.env.remote_redis_url | default "" | quote }}
+  {{- end }}
+---

--- a/charts/plane-ce/templates/config-secrets/live-env.yaml
+++ b/charts/plane-ce/templates/config-secrets/live-env.yaml
@@ -10,7 +10,7 @@ data:
   LIVE_SENTRY_TRACES_SAMPLE_RATE: {{ .Values.env.live_sentry_traces_sample_rate | default "" | quote }}
   LIVE_BASE_PATH: "/live"
 
-  {{- if .Values.services.redis.local_setup }}
+  {{- if .Values.redis.local_setup }}
   REDIS_URL: "redis://{{ .Release.Name }}-redis.{{ .Release.Namespace }}.svc.cluster.local:6379/"
   {{- else }}
   REDIS_URL: {{ .Values.env.remote_redis_url | default "" | quote }}

--- a/charts/plane-ce/templates/ingress.yaml
+++ b/charts/plane-ce/templates/ingress.yaml
@@ -42,6 +42,13 @@ spec:
               service:
                 port:
                   number: 3000
+                name: {{ .Release.Name }}-live
+            path: /live/
+            pathType: Prefix
+          - backend:
+              service:
+                port:
+                  number: 3000
                 name: {{ .Release.Name }}-space
             path: /spaces
             pathType: Prefix

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-live
         imagePullPolicy: Always
-        image: {{ .Values.live.image | default "makeplane/plane-live" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.live.image | default "makeplane/plane-live:preview" }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -1,0 +1,65 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-live
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+spec:
+  {{- if not .Values.live.assign_cluster_ip }}
+  clusterIP: None
+  {{- end }}
+  ports:
+  - name: live-3000
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-live-wl
+spec:
+  replicas: {{ .Values.live.replicas | default 1}}
+  selector:
+    matchLabels:
+      app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+      annotations:
+        timestamp: {{ now | quote }}
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-live
+        imagePullPolicy: Always
+        image: {{ .Values.live.image | default "makeplane/plane-live" }}:{{ .Values.planeVersion }}
+        stdin: true
+        tty: true
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "50m"
+          limits:
+            memory: {{ .Values.live.memoryLimit  | default "1000Mi" | quote }}
+            cpu: {{ .Values.live.cpuLimit | default "500m" | quote}}
+        command:
+          - node
+        args:
+          - live/dist/server.js
+        envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}-live-vars
+              optional: false
+      serviceAccount: {{ .Release.Name }}-srv-account
+      serviceAccountName: {{ .Release.Name }}-srv-account
+
+---

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-live
         imagePullPolicy: Always
-        image: {{ .Values.live.image | default "makeplane/plane-live:preview" }}
+        image: {{ .Values.live.image | default "makeplane/plane-live" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -95,7 +95,7 @@ live:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-live:preview
+  image: makeplane/plane-live
   pullPolicy: Always
   assign_cluster_ip: false
 

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -91,6 +91,14 @@ admin:
   pullPolicy: Always
   assign_cluster_ip: false
 
+live:
+  replicas: 1
+  memoryLimit: 1000Mi
+  cpuLimit: 500m
+  image: makeplane/plane-live
+  pullPolicy: Always
+  assign_cluster_ip: false
+
 api:
   replicas: 1
   memoryLimit: 1000Mi
@@ -141,3 +149,8 @@ env:
 
   cors_allowed_origins: ""
   default_cluster_domain: cluster.local
+
+  live_sentry_dsn: ""
+  live_sentry_environment: ""
+  live_sentry_traces_sample_rate: ""
+

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -95,7 +95,7 @@ live:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-live
+  image: makeplane/plane-live:preview
   pullPolicy: Always
   assign_cluster_ip: false
 


### PR DESCRIPTION
Add `live service` to `Plane` CE Helm chart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Live Docker Image" configuration with enhanced settings for the live environment.
	- Added a new path for `/live/` in the Ingress resource to route traffic to the live service.
	- Created a new Service and Deployment for the live application, including resource specifications and environment variables.
	- Updated the configuration file to support the new live component with specific resource allocations.
	- Added a new section in the README for "Live Service Deployment" with detailed configuration settings.

- **Bug Fixes**
	- Adjusted the default value for `admin.assign_cluster_ip` from `false` to `true`. 

- **Version Update**
	- Incremented application version from `1.0.24` to `1.0.25`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->