### PR TITLE
feat: support existingSecret for plane-enterprise chart

### DIFF
--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -260,6 +260,7 @@
 |---|:---:|:---:|---|
 | env.storageClass | longhorn |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
 | env.secret_key | 60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5 | Yes | This must a random string which is used for hashing/encrypting the sensitive data within the application. Once set, changing this might impact the already hashed/encrypted data|
+| env.existingSecret | "" | No | If you want to use an existing secret for the application, set this value as per your existing secret name. It must contain keys for `SECRET_KEY` and optionally: `DATABASE_URL`, and `AMQP_URL`.|
   
 ## Custom Ingress Routes
 

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -207,6 +207,11 @@ questions:
     label: "Sentry Environment"
     type: string
     default: "Development"
+  - variable: env.existingSecret
+    label: "Existing Secret for app env"
+    type: string
+    default: ""
+    description: "Should contain the key `SECRET_KEY` and optionally: `DATABASE_URL`, and `AMQP_URL`"
   - variable: env.secret_key
     label: "Random Secret Key"
     type: string
@@ -389,6 +394,11 @@ questions:
     type: string
     default: "admin"
     show_if: "services.minio.local_setup=true"
+  - variable: services.minio.existingSecret
+    label: "Existing Secret for doc-store"
+    type: string
+    default: ""
+    description: "Should contain the keys `AWS_SECRET_ACCESS_KEY` and `MINIO_ROOT_PASSWORD` (if minio.local_setup=true)"
   - variable: services.minio.root_password
     label: "Root Password"
     type: password

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -5,3 +5,11 @@
 {{- define "hashString" -}}
 {{- printf "%s%s%s%s" .Values.license.licenseServer .Values.license.licenseDomain .Release.Namespace .Release.Name | sha256sum  -}}
 {{- end -}}
+
+{{- define "doc-store-secret" -}}
+{{- default (printf "%s-doc-store-secrets" .Release.Name) .Values.services.minio.existingSecret -}}
+{{- end -}}
+
+{{- define "app-secret" -}}
+{{- default (printf "%s-app-secrets" .Release.Name) .Values.env.existingSecret -}}
+{{- end -}}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -1,3 +1,4 @@
+{{- if (not .Values.env.existingSecret) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -6,6 +7,22 @@ metadata:
   name: {{ .Release.Name }}-app-secrets
 data:
   SECRET_KEY: {{ .Values.env.secret_key | default "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5" | b64enc | quote }}
+
+  {{ if .Values.services.postgres.local_setup }}
+  DATABASE_URL: "postgresql://{{ .Values.env.pgdb_username }}:{{ .Values.env.pgdb_password }}@{{ .Release.Name }}-pgdb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.env.pgdb_name }}"
+  {{ else if .Values.env.pgdb_remote_url }}
+  DATABASE_URL: {{ .Values.env.pgdb_remote_url}}
+  {{ else }}
+  DATABASE_URL: ""
+  {{ end }}
+
+  {{- if .Values.services.rabbitmq.local_setup }}
+  AMQP_URL: "amqp://{{ .Values.services.rabbitmq.default_user}}:{{ .Values.services.rabbitmq.default_password}}@{{ .Release.Name }}-rabbitmq.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}/"
+  {{- else if .Values.services.rabbitmq.external_rabbitmq_url }}
+  AMQP_URL: {{ .Values.services.rabbitmq.external_rabbitmq_url}}
+  {{- else }}
+  AMQP_URL: ""
+  {{ end }}
 
 ---
 
@@ -37,25 +54,9 @@ data:
     {{- else}}
     CORS_ALLOWED_ORIGINS: "http://{{ .Values.license.licenseDomain }},https://{{ .Values.license.licenseDomain }}"
     {{- end }}
-    
+
     {{- if .Values.services.redis.local_setup }}
     REDIS_URL: "redis://{{ .Release.Name }}-redis.{{ .Release.Namespace }}.svc.cluster.local:6379/"
     {{- else }}
     REDIS_URL: {{ .Values.env.remote_redis_url | default "" | quote }}
     {{- end }}
-
-    {{ if .Values.services.postgres.local_setup }}
-    DATABASE_URL: "postgresql://{{ .Values.env.pgdb_username }}:{{ .Values.env.pgdb_password }}@{{ .Release.Name }}-pgdb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.env.pgdb_name }}"
-    {{ else if .Values.env.pgdb_remote_url }}
-    DATABASE_URL: {{ .Values.env.pgdb_remote_url}}
-    {{ else }}
-    DATABASE_URL: ""
-    {{ end }}
-
-    {{- if .Values.services.rabbitmq.local_setup }}
-    AMQP_URL: "amqp://{{ .Values.services.rabbitmq.default_user}}:{{ .Values.services.rabbitmq.default_password}}@{{ .Release.Name }}-rabbitmq.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}/"
-    {{- else if .Values.services.rabbitmq.external_rabbitmq_url }}
-    AMQP_URL: {{ .Values.services.rabbitmq.external_rabbitmq_url}}
-    {{- else }}
-    AMQP_URL: ""
-    {{ end }}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -25,6 +25,7 @@ data:
   {{ end }}
 
 ---
+{{- end }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/plane-enterprise/templates/config-secrets/doc-strore.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/doc-strore.yaml
@@ -1,3 +1,4 @@
+{{- if and (or .Values.services.minio.root_password .Values.env.aws_secret_access_key) (not .Values.services.minio.existingSecret) }}
 
 apiVersion: v1
 kind: Secret
@@ -7,13 +8,14 @@ metadata:
   name: {{ .Release.Name }}-doc-store-secrets
 data:
   {{ if .Values.services.minio.local_setup }}
-  MINIO_ROOT_PASSWORD: {{ .Values.services.minio.root_password | default "password" | b64enc | quote}}
+  MINIO_ROOT_PASSWORD: {{ .Values.services.minio.root_password | default "password" | b64enc | quote }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.services.minio.root_password | default "password" | b64enc | quote  }}
   {{ else }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.env.aws_secret_access_key | default "" | b64enc | quote  }}
   {{ end }}
 
 ---
+{{- end }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -58,13 +58,13 @@ spec:
               name: {{ .Release.Name }}-app-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-app-secrets
+              name: {{ include "app-secret" . }}
               optional: false
           - configMapRef:
               name: {{ .Release.Name }}-doc-store-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-doc-store-secrets
+              name: {{ include "doc-store-secret" . }}
               optional: false
         readinessProbe:
           failureThreshold: 30

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -36,13 +36,13 @@ spec:
               name: {{ .Release.Name }}-app-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-app-secrets
+              name: {{ include "app-secret" . }}
               optional: false
           - configMapRef:
               name: {{ .Release.Name }}-doc-store-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-doc-store-secrets
+              name: {{ include "doc-store-secret" . }}
               optional: false
 
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/templates/workloads/migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/migrator.job.yaml
@@ -24,13 +24,13 @@ spec:
               name: {{ .Release.Name }}-app-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-app-secrets
+              name: {{ include "app-secret" . }}
               optional: false
           - configMapRef:
               name: {{ .Release.Name }}-doc-store-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-doc-store-secrets
+              name: {{ include "doc-store-secret" . }}
               optional: false
       restartPolicy: OnFailure
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -55,7 +55,7 @@ spec:
               name: {{ .Release.Name }}-doc-store-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-doc-store-secrets
+                name: {{ include "doc-store-secret" . }}
               optional: false
         volumeMounts:
         - mountPath: /data
@@ -113,7 +113,7 @@ spec:
                 name: {{ .Release.Name }}-doc-store-vars
                 optional: false
             - secretRef:
-                name: {{ .Release.Name }}-doc-store-secrets
+                name: {{ include "doc-store-secret" . }}
                 optional: false
           image: minio/mc
           imagePullPolicy: Always

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -36,13 +36,13 @@ spec:
               name: {{ .Release.Name }}-app-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-app-secrets
+              name: {{ include "app-secret" . }}
               optional: false
           - configMapRef:
               name: {{ .Release.Name }}-doc-store-vars
               optional: false
           - secretRef:
-              name: {{ .Release.Name }}-doc-store-secrets
+              name: {{ include "doc-store-secret" . }}
               optional: false
 
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -15,9 +15,7 @@ ingress:
   minioHost: ''
   rabbitmqHost: ''
   ingressClass: 'nginx'
-  ingress_annotations: {
-    "nginx.ingress.kubernetes.io/proxy-body-size": "5m",
-  }
+  ingress_annotations: { 'nginx.ingress.kubernetes.io/proxy-body-size': '5m' }
 
 ssl:
   createIssuer: false
@@ -60,6 +58,9 @@ services:
     volumeSize: 3Gi
     root_user: admin
     root_password: password
+    # -- The name of an existing secret with Minio credentials (must contain keys `AWS_SECRET_ACCESS_KEY` and `MINIO_ROOT_PASSWORD` (if minio.local_setup)).
+    # When it's set, the `minio.root_password` parameter is ignored
+    existingSecret: ''
     assign_cluster_ip: false
 
   web:
@@ -82,7 +83,7 @@ services:
     cpuLimit: 500m
     image: registry.plane.tools/plane/space-enterprise
     assign_cluster_ip: false
-    
+
   admin:
     replicas: 1
     memoryLimit: 1000Mi
@@ -103,7 +104,7 @@ services:
     cpuLimit: 500m
     image: registry.plane.tools/plane/backend-enterprise
     assign_cluster_ip: false
-    
+
   worker:
     replicas: 1
     memoryLimit: 1000Mi
@@ -136,7 +137,7 @@ env:
   aws_secret_access_key: ''
   aws_region: ''
   aws_s3_endpoint_url: ''
-  
+
   secret_key: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
 
   sentry_dsn: ''
@@ -149,3 +150,6 @@ env:
   live_sentry_environment: ""
   live_sentry_traces_sample_rate: ""
 
+  # -- The name of an existing secret with app env values (must contain keys `SECRET_KEY`, `DATABASE_URL. and `AMQP_URL`).
+  # When it's set, the `env.` parameter is ignored
+  existingSecret: ""


### PR DESCRIPTION
This change introduces support for supplying an existingSecret for doc-store and app-secrets; previously, users had to specify secret values such as aws access keys, database urls with passwords, and the application secret_key. This makes it impossible to safely manage the helm installation via GitOps. Users may continue to provide values this way for simplicity, but may also choose to create these secrets themselves and specify them by reference.