### PR TITLE
Postgres version update and minio client image add in values file #46

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -6,7 +6,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 type: application
 
 version: 1.0.27
-appVersion: "0.23.0"
+appVersion: "0.24.0"
 
 home: https://plane.so
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.0.26
+version: 1.0.27
 appVersion: "0.23.0"
 
 home: https://plane.so

--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.0.24
+version: 1.0.25
 appVersion: "0.22.0"
 
 home: https://plane.so

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -122,6 +122,7 @@
 |---|:---:|:---:|---|
 | minio.local_setup | true |  | Plane uses `minio` as the default file storage drive. This storage can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws S3 or similar services). Set this to  `true` when you choose to setup stateful deployment of `postgres`. Mark it as `false` when using a remotely hosted database |
 | minio.image | minio/minio:latest |  | Using this key, user must provide the docker image name to setup the stateful deployment of `minio`. (must be set when `minio.local_setup=true`)|
+| minio.image_mc | minio/mc:latest |  | Using this key, user must provide the docker image name to setup the job deployment of `minio client`. (must be set when `services.minio.local_setup=true`)|
 | minio.volumeSize | 5Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
 | minio.root_user | admin |  |  Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the username for the stateful deployment. |
 | minio.root_password | password |  | Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the password for the stateful deployment. |

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -77,7 +77,7 @@
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
 | postgres.local_setup | true |  | Plane uses `postgres` as the primary database to store all the transactional data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to  `true` when you choose to setup stateful deployment of `postgres`. Mark it as `false` when using a remotely hosted database |
-| postgres.image | postgres:15.5-alpine |  | Using this key, user must provide the docker image name to setup the stateful deployment of `postgres`. (must be set when `postgres.local_setup=true`)|
+| postgres.image | postgres:15.7-alpine |  | Using this key, user must provide the docker image name to setup the stateful deployment of `postgres`. (must be set when `postgres.local_setup=true`)|
 | postgres.servicePort | 5432 |  | This key sets the default port number to be used while setting up stateful deployment of `postgres`. |
 | postgres.cliConnectPort |  | | If you intend to access the hosted stateful deployment of postgres using any of the client tools (e.g Postico), this key helps you expose the port. The mentioned port must not be occupied by any other applicaiton |
 | postgres.volumeSize | 5Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -366,6 +366,11 @@ questions:
     type: string
     default: "minio/minio:latest"
     show_if: "minio.local_setup=true"
+  - variable: minio.image_mc
+    label: "MinIO Client Docker Image"
+    type: string
+    default: "minio/mc:latest"
+    show_if: "minio.local_setup=true"
   - variable: minio.root_user
     label: "Root User"
     type: string

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -34,9 +34,9 @@ questions:
     label: "Image Pull Policy"
     type: enum
     options:
-      - "Always"
-      - "IfNotPresent"
-      - "Never"
+    - "Always"
+    - "IfNotPresent"
+    - "Never"
     default: "IfNotPresent"
   - variable: web.replicas
     label: "Default Replica Count"
@@ -54,7 +54,6 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: false
-  
 
 - variable: space.image
   label: Space Docker Image
@@ -67,9 +66,9 @@ questions:
     label: "Image Pull Policy"
     type: enum
     options:
-      - "Always"
-      - "IfNotPresent"
-      - "Never"
+    - "Always"
+    - "IfNotPresent"
+    - "Never"
     default: "IfNotPresent"
   - variable: space.replicas
     label: "Default Replica Count"
@@ -99,9 +98,9 @@ questions:
     label: "Image Pull Policy"
     type: enum
     options:
-      - "Always"
-      - "IfNotPresent"
-      - "Never"
+    - "Always"
+    - "IfNotPresent"
+    - "Never"
     default: "IfNotPresent"
   - variable: admin.replicas
     label: "Default Replica Count"
@@ -132,9 +131,9 @@ questions:
     label: "Image Pull Policy"
     type: enum
     options:
-      - "Always"
-      - "IfNotPresent"
-      - "Never"
+    - "Always"
+    - "IfNotPresent"
+    - "Never"
     default: "IfNotPresent"
   - variable: live.replicas
     label: "Default Replica Count"
@@ -152,7 +151,7 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: false
-  
+
   - variable: env.live_sentry_dsn
     label: "Live Sentry DSN"
     type: string
@@ -178,9 +177,9 @@ questions:
     label: "Image Pull Policy"
     type: enum
     options:
-      - "Always"
-      - "IfNotPresent"
-      - "Never"
+    - "Always"
+    - "IfNotPresent"
+    - "Never"
     default: "IfNotPresent"
   - variable: api.replicas
     label: "Default Replica Count"
@@ -216,6 +215,7 @@ questions:
     required: true
     default: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
     subquestions:
+
 
 - variable: worker.replicas
   label: "Default Replica Count"
@@ -294,7 +294,7 @@ questions:
   - variable: postgres.image
     label: "Docker Image"
     type: string
-    default: "postgres:15.5-alpine"
+    default: "postgres:15.7-alpine"
     show_if: "postgres.local_setup=true"
   - variable: postgres.servicePort
     label: Service Port
@@ -356,9 +356,9 @@ questions:
     label: "Image Pull Policy"
     type: enum
     options:
-      - "Always"
-      - "IfNotPresent"
-      - "Never"
+    - "Always"
+    - "IfNotPresent"
+    - "Never"
     default: "IfNotPresent"
     show_if: "rabbitmq.local_setup=true"
   - variable: rabbitmq.servicePort
@@ -511,9 +511,9 @@ questions:
     label: "SSL Issuer"
     type: enum
     options:
-      - "http"
-      - "cloudflare"
-      - "digitalocean"
+    - "http"
+    - "cloudflare"
+    - "digitalocean"
     default: "http"
   - variable: ssl.server
     label: "Let's Encrypt Server URL"
@@ -533,4 +533,3 @@ questions:
     label: "Enable to generate certificates"
     type: boolean
     default: false
-    

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -115,7 +115,7 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-doc-store-secrets
                 optional: false
-          image: minio/mc
+          image: {{ .Values.minio.image_mc }}
           imagePullPolicy: {{ .Values.minio.pullPolicy }}
           name: {{ .Release.Name }}-minio-bucket
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -36,7 +36,7 @@ redis:
 
 postgres:
   local_setup: true
-  image: postgres:15.5-alpine
+  image: postgres:15.7-alpine
   servicePort: 5432
   cliConnectPort: ""
   storageClass: longhorn
@@ -59,6 +59,7 @@ rabbitmq:
 
 minio:
   image: minio/minio:latest
+  image_mc: minio/mc:latest
   local_setup: true
   pullPolicy: IfNotPresent
   root_password: password

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.0.12
+version: 1.0.13
 appVersion: "1.3.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.5.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -6,7 +6,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 type: application
 
 version: 1.1.1
-appVersion: "1.5.0"
+appVersion: "1.5.1"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -147,6 +147,7 @@
 |---|:---:|:---:|---|
 | services.minio.local_setup | true |  | Plane uses `minio` as the default file storage drive. This storage can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws S3 or similar services). Set this to  `true` when you choose to setup stateful deployment of `minio`. Mark it as `false` when using a remotely hosted database |
 | services.minio.image | registry.plane.tools/plane/minio:latest |  | Using this key, user must provide the docker image name to setup the stateful deployment of `minio`. (must be set when `services.minio.local_setup=true`)|
+| services.minio.image_mc | minio/mc:latest |  | Using this key, user must provide the docker image name to setup the job deployment of `minio client`. (must be set when `services.minio.local_setup=true`)|
 | services.minio.volumeSize | 3Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
 | services.minio.root_user | admin |  |  Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the username for the stateful deployment. |
 | services.minio.root_password | password |  | Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the password for the stateful deployment. |

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -106,7 +106,7 @@
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
 | services.postgres.local_setup | true |  | Plane uses `postgres` as the primary database to store all the transactional data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to  `true` when you choose to setup stateful deployment of `postgres`. Mark it as `false` when using a remotely hosted database |
-| services.postgres.image | registry.plane.tools/plane/postgres:15.5-alpine |  | Using this key, user must provide the docker image name to setup the stateful deployment of `postgres`. (must be set when `services.postgres.local_setup=true`)|
+| services.postgres.image | registry.plane.tools/plane/postgres:15.7-alpine |  | Using this key, user must provide the docker image name to setup the stateful deployment of `postgres`. (must be set when `services.postgres.local_setup=true`)|
 | services.postgres.servicePort | 5432 |  | This key sets the default port number to be used while setting up stateful deployment of `postgres`. |
 | services.postgres.cliConnectPort |  | | If you intend to access the hosted stateful deployment of postgres using any of the client tools (e.g Postico), this key helps you expose the port. The mentioned port must not be occupied by any other applicaiton|
 | services.postgres.volumeSize | 2Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -389,6 +389,11 @@ questions:
     type: string
     default: "registry.plane.tools/plane/minio:latest"
     show_if: "services.minio.local_setup=true"
+  - variable: services.minio.image_mc
+    label: "MinIO Client Docker Image"
+    type: string
+    default: "minio/mc:latest"
+    show_if: "services.minio.local_setup=true"
   - variable: services.minio.root_user
     label: "Root User"
     type: string

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -89,7 +89,7 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: false
-  
+
 - variable: services.space.replicas
   label: "Default Replica Count"
   type: int
@@ -285,7 +285,7 @@ questions:
   - variable: services.postgres.image
     label: "Docker Image"
     type: string
-    default: "registry.plane.tools/plane/postgres:15.5-alpine"
+    default: "registry.plane.tools/plane/postgres:15.7-alpine"
     show_if: "services.postgres.local_setup=true"
   - variable: services.postgres.servicePort
     label: Service Port
@@ -372,7 +372,7 @@ questions:
     label: "Remote URL"
     type: string
     show_if: "services.rabbitmq.local_setup=false"
-    
+
 - variable: services.minio.local_setup
   label: "Install Minio"
   type: boolean
@@ -475,9 +475,9 @@ questions:
     label: "SSL Issuer"
     type: enum
     options:
-      - "http"
-      - "cloudflare"
-      - "digitalocean"
+    - "http"
+    - "cloudflare"
+    - "digitalocean"
     default: "http"
   - variable: ssl.server
     label: "Let's Encrypt Server URL"
@@ -497,4 +497,3 @@ questions:
     label: "Enable to generate certificates"
     type: boolean
     default: false
-

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -115,7 +115,7 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-doc-store-secrets
                 optional: false
-          image: minio/mc
+          image: {{ .Values.services.minio.image_mc }}
           imagePullPolicy: Always
           name: {{ .Release.Name }}-minio-bucket
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -37,7 +37,7 @@ services:
 
   postgres:
     local_setup: true
-    image: registry.plane.tools/plane/postgres:15.5-alpine
+    image: registry.plane.tools/plane/postgres:15.7-alpine
     servicePort: 5432
     cliConnectPort: ''
     volumeSize: 2Gi
@@ -57,6 +57,7 @@ services:
   minio:
     local_setup: true
     image: registry.plane.tools/plane/minio:latest
+    image_mc: minio/mc:latest
     volumeSize: 3Gi
     root_user: admin
     root_password: password

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v1.5.0
+planeVersion: v1.5.1
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION
Changes:
PG Version - v15.7-alpine
MinIO Client image using values.yml file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for MinIO deployment, allowing users to specify the Docker image for the MinIO client.
	- Added conditional checks for MinIO local setup in the configuration files.

- **Updates**
	- Version numbers updated for both `plane-ce` and `plane-enterprise` applications.
	- PostgreSQL image version updated to `15.7-alpine`.

- **Documentation**
	- Enhanced README files to include new configuration settings and clarify deployment requirements for MinIO services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->