### PR TITLE
Fix gpg key

### DIFF
--- a/.github/workflows/chart-preview.yml
+++ b/.github/workflows/chart-preview.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4

--- a/.github/workflows/chart-preview.yml
+++ b/.github/workflows/chart-preview.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4


### PR DESCRIPTION
Changed build the image from `ubuntu-latest` to `ubuntu-22.04`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated workflow for Helm Preview Build with enhanced GPG key management.
	- Added HTML index file generation for available builds.

- **Chores**
	- Changed runner environment from `ubuntu-latest` to `ubuntu-22.04`.
	- Retained AWS CLI installation for artifact uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->