### PR TITLE
chore: add pod annotations merge functionality from values.yaml

### DIFF
--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -568,3 +568,10 @@ questions:
   type: string
   default: ""
   group: "External Secrets"
+- variable: podAnnotations
+  label: "Pod Annotations"
+  group: "Pod Configuration"
+  type: dict
+  description: "Add custom annotations to pods. Will be merged with existing annotations."
+  default: {}
+  required: false

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-admin

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -15,6 +15,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-beat-worker

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-live

--- a/charts/plane-ce/templates/workloads/migrator.job.yaml
+++ b/charts/plane-ce/templates/workloads/migrator.job.yaml
@@ -12,6 +12,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api-migrate

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-space

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-web

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -15,6 +15,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-worker

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -160,3 +160,5 @@ env:
   live_sentry_dsn: ""
   live_sentry_environment: ""
   live_sentry_traces_sample_rate: ""
+
+podAnnotations: {}

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -721,3 +721,10 @@ questions:
   type: string
   default: ""
   group: "External Secrets"
+- variable: podAnnotations
+  label: "Pod Annotations"
+  group: "Pod Configuration"
+  type: dict
+  description: "Add custom annotations to pods. Will be merged with existing annotations."
+  default: {}
+  required: false

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-admin

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -15,6 +15,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-beat-worker

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-live

--- a/charts/plane-enterprise/templates/workloads/migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/migrator.job.yaml
@@ -12,6 +12,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api-migrate

--- a/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
@@ -34,6 +34,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-monitor
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - image: {{ .Values.services.monitor.image | default "registry.plane.tools/plane/monitor-enterprise" }}:{{ .Values.planeVersion }}

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -36,6 +36,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       initContainers:
       - name: wait-for-rabbitmq

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-space

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -37,6 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-web

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -15,6 +15,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
       annotations:
         timestamp: {{ now | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-worker

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -199,3 +199,5 @@ env:
     request_interval: 400
     hmac_secret_key: ''
     cors_allowed_origins: ''
+
+podAnnotations: {}


### PR DESCRIPTION
## What does this PR do?
- Adds support for dynamic pod annotations via `values.yaml`
- Implements merge functionality with existing hardcoded annotations