### PR TITLE
plane-ee: add envs `MINIO_ENDPOINT_SSL` and `API_KEY_RATE_LIMIT`

### DIFF
--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -214,14 +214,11 @@ questions:
     type: string
     required: true
     default: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
-  - variable: minio.env.minio_endpoint_ssl
-    label: "Minio Endpoint SSL"
-    type: boolean
-    default: false
   - variable: env.api_key_rate_limit
     label: "API Key Rate Limit"
     type: string
     default: "60/minute"
+
 - variable: worker.replicas
   label: "Default Replica Count"
   type: int
@@ -491,6 +488,10 @@ questions:
     label: "FIle Upload Size Limit"
     type: string
     default: "5242880"
+  - variable: minio.env.minio_endpoint_ssl
+    label: "Minio Endpoint SSL"
+    type: boolean
+    default: false
 
 - variable: ingress.enabled
   label: "Install Ingress"

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.1.6
-appVersion: "1.8.1"
+version: 1.1.7
+appVersion: "1.8.3"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -11,7 +11,7 @@
       Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
       ```bash
-      PLANE_VERSION=v1.8.1 # or the last released version
+      PLANE_VERSION=v1.8.3 # or the last released version
       DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
       ```
 
@@ -65,7 +65,7 @@
           ```
 
           Make sure you set the minimum required values as below.
-          - `planeVersion: v1.8.1 <or the last released version>`
+          - `planeVersion: v1.8.3 <or the last released version>`
           - `license.licenseDomain: <The domain you have specified to host Plane>`
           - `ingress.enabled: <true | false>`
           - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
@@ -100,7 +100,7 @@
 
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
-| planeVersion | v1.8.1 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
+| planeVersion | v1.8.3 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -156,6 +156,7 @@
 | services.minio.volumeSize | 3Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
 | services.minio.root_user | admin |  |  Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the username for the stateful deployment. |
 | services.minio.root_password | password |  | Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the password for the stateful deployment. |
+| services.minio.env.minio_endpoint_ssl | false |  | (Optional) Env to enforce HTTPS when connecting to minio uploads bucket  |
 | env.docstore_bucket | uploads | Yes | Storage bucket name is required as part of configuration. This is where files will be uploaded irrespective of if you are using `Minio` or external `S3` (or compatible) storage service |
 | env.doc_upload_size_limit | 5242880 | Yes | Document Upload Size Limit (default to 5Mb) |
 | services.minio.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
@@ -233,6 +234,7 @@
 | services.api.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `api`. |
 | env.sentry_dsn |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
 | env.sentry_environment |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
+| env.api_key_rate_limit | 60/minute |  | (optional) User can set the maximum number of requests the API can handle in a given time frame.|
 | services.api.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
 
 ### Silo Deployment

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -376,15 +376,11 @@ questions:
     type: string
     required: true
     default: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
-  - variable: services.minio.env.minio_endpoint_ssl
-    label: "Minio Endpoint SSL"
-    type: boolean
-    default: false
-    show_if: "services.minio.local_setup=true"
   - variable: env.api_key_rate_limit
     label: "API Key Rate Limit"
     type: string
     default: "60/minute"
+
 - variable: services.worker.replicas
   label: "Default Replica Count"
   type: int
@@ -638,6 +634,11 @@ questions:
     label: "File Upload Size Limit"
     type: string
     default: "5242880"
+  - variable: services.minio.env.minio_endpoint_ssl
+    label: "Minio Endpoint SSL"
+    type: boolean
+    default: false
+    show_if: "services.minio.local_setup=true"
 
 - variable: ingress.enabled
   label: "Enable Ingress"

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -20,7 +20,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v1.8.1
+  default: v1.8.3
   required: true
   group: "Docker Registry"
   subquestions:

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -376,7 +376,15 @@ questions:
     type: string
     required: true
     default: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
-
+  - variable: services.minio.env.minio_endpoint_ssl
+    label: "Minio Endpoint SSL"
+    type: boolean
+    default: false
+    show_if: "services.minio.local_setup=true"
+  - variable: env.api_key_rate_limit
+    label: "API Key Rate Limit"
+    type: string
+    default: "60/minute"
 - variable: services.worker.replicas
   label: "Default Replica Count"
   type: int

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -45,6 +45,9 @@ data:
   PAYMENT_SERVER_BASE_URL: "http://{{ .Release.Name }}-monitor.{{ .Release.Namespace }}.svc.cluster.local:8080/"
   FEATURE_FLAG_SERVER_BASE_URL: "http://{{ .Release.Name }}-monitor.{{ .Release.Namespace }}.svc.cluster.local:8080/"
 
+  API_KEY_RATE_LIMIT: {{ .Values.env.api_key_rate_limit | default "60/minute" | quote }}
+  MINIO_ENDPOINT_SSL: {{ .Values.services.minio.env.minio_endpoint_ssl | default false | ternary "1" "0" | quote }}
+
   SENTRY_DSN: {{ .Values.env.sentry_dsn | default "" | quote}}
   SENTRY_ENVIRONMENT: {{ .Values.env.sentry_environment | default "" | quote}}
   DEBUG: "0"

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -63,6 +63,8 @@ services:
     root_user: admin
     root_password: password
     assign_cluster_ip: false
+    env:
+      minio_endpoint_ssl: false
 
   web:
     replicas: 1
@@ -179,6 +181,7 @@ env:
   aws_s3_endpoint_url: ''
 
   secret_key: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
+  api_key_rate_limit: "60/minute"
 
   sentry_dsn: ''
   sentry_environment: ''

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v1.8.1
+planeVersion: v1.8.3
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated application and release version identifiers to v1.8.3.
- **New Features**
  - Added a configurable API key rate limiting option (default: 60/minute).
  - Introduced an option to toggle SSL for the storage service endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->