### PR TITLE
Support TLS Secret Configuration in Both Helm Charts

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.0.30
-appVersion: "0.25.2"
+version: 1.1.0
+appVersion: "0.25.3"
 
 home: https://plane.so
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -237,6 +237,7 @@
 | ssl.server | <https://acme-v02.api.letsencrypt.org/directory> |  | Issuer creation configuration need the certificate generation authority server url. Default URL is the `Let's Encrypt` server|
 | ssl.email | <plane@example.com> |  | Certificate generation authority needs a valid email id before generating certificate. Required when `ssl.createIssuer=true`  |
 | ssl.generateCerts | false |  | After creating the issuers, user can still not create the certificate untill sure of configuration. Setting this to `true` will try to generate SSL certificate and associate with ingress. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=true` |
+| ssl.tls_secret_name |  |  | If you have a custom TLS secret name, set this to the name of the secret. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=false` |
 
 ### Common Environment Settings
 

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -556,6 +556,13 @@ questions:
     type: boolean
     default: false
 
+- variable: ssl.tls_secret_name
+  label: "Custom TLS Secret Name"
+  type: string
+  default: ""
+  group: "Ingress"
+  show_if: "ssl.createIssuer=false"
+
 - variable: external_secrets.rabbitmq_existingSecret
   label: "RabbitMQ Secrets File Name"
   type: string

--- a/charts/plane-ce/templates/certs/cert-issuers.yaml
+++ b/charts/plane-ce/templates/certs/cert-issuers.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ssl.createIssuer }}
+{{- if and .Values.ingress.enabled .Values.ssl.createIssuer (empty .Values.ssl.tls_secret_name) }} 
 
 apiVersion: v1
 kind: Secret

--- a/charts/plane-ce/templates/certs/certs.yaml
+++ b/charts/plane-ce/templates/certs/certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ssl.createIssuer .Values.ssl.generateCerts }}
+{{- if and .Values.ingress.enabled .Values.ssl.createIssuer .Values.ssl.generateCerts (empty .Values.ssl.tls_secret_name) }}
 
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/plane-ce/templates/ingress.yaml
+++ b/charts/plane-ce/templates/ingress.yaml
@@ -93,7 +93,19 @@ spec:
             path: /
             pathType: Prefix
     {{- end }}
-  {{- if .Values.ssl.generateCerts }}
+
+  {{- if .Values.ssl.tls_secret_name }}
+  tls:
+    - hosts:
+      - {{ .Values.ingress.appHost | quote }}
+      {{- if and .Values.minio.local_setup .Values.ingress.minioHost }}
+      - {{ .Values.ingress.minioHost | quote }}
+      {{- end }}
+      {{- if and .Values.rabbitmq.local_setup .Values.ingress.rabbitmqHost }}
+      - {{ .Values.ingress.rabbitmqHost | quote }}
+      {{- end }}
+      secretName: {{ .Values.ssl.tls_secret_name }}
+  {{- else if and .Values.ssl.generateCerts .Values.ssl.createIssuer }}
   tls:
     - hosts:
       - {{ .Values.ingress.appHost | quote }}

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -16,6 +16,8 @@ ingress:
 
 # SSL Configuration - Valid only if ingress.enabled is true
 ssl:
+  tls_secret_name: "" # If you have a custom TLS secret name
+  # If you want to use Let's Encrypt, set createIssuer and generateCerts to true
   createIssuer: false
   issuer: "http" # Allowed : cloudflare, digitalocean, http
   token: "" # not required for http

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.1.7
+version: 1.1.8
 appVersion: "1.8.3"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -299,6 +299,7 @@
 | ssl.server | <https://acme-v02.api.letsencrypt.org/directory> |  | Issuer creation configuration need the certificate generation authority server url. Default URL is the `Let's Encrypt` server|
 | ssl.email | <plane@example.com> |  | Certificate generation authority needs a valid email id before generating certificate. Required when `ssl.createIssuer=true`  |
 | ssl.generateCerts | false |  | After creating the issuers, user can still not create the certificate untill sure of configuration. Setting this to `true` will try to generate SSL certificate and associate with ingress. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=true` |
+| ssl.tls_secret_name |  |  | If you have a custom TLS secret name, set this to the name of the secret. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=false` |
 
 ### Common Environment Settings
 

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -700,6 +700,13 @@ questions:
     type: boolean
     default: false
 
+- variable: ssl.tls_secret_name
+  label: "Custom TLS Secret Name"
+  type: string
+  default: ""
+  group: "Ingress"  
+  show_if: "ssl.createIssuer=false"
+
 - variable: external_secrets.rabbitmq_existingSecret
   label: "RabbitMQ Secrets File Name"
   type: string

--- a/charts/plane-enterprise/templates/certs/cert-issuers.yaml
+++ b/charts/plane-enterprise/templates/certs/cert-issuers.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ssl.createIssuer }}
+{{- if and .Values.ingress.enabled .Values.ssl.createIssuer (empty .Values.ssl.tls_secret_name) }}
 
 apiVersion: v1
 kind: Secret

--- a/charts/plane-enterprise/templates/certs/certs.yaml
+++ b/charts/plane-enterprise/templates/certs/certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ssl.createIssuer .Values.ssl.generateCerts }}
+{{- if and .Values.ingress.enabled .Values.ssl.createIssuer .Values.ssl.generateCerts (empty .Values.ssl.tls_secret_name) }}
 
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -107,7 +107,19 @@ spec:
             path: /
             pathType: Prefix
     {{- end }}
-  {{- if .Values.ssl.generateCerts }}
+
+  {{- if .Values.ssl.tls_secret_name}}
+  tls:
+    - hosts:
+      - {{ .Values.license.licenseDomain | quote }}
+      {{- if and .Values.services.minio.local_setup .Values.ingress.minioHost }}
+      - {{ .Values.ingress.minioHost | quote }}
+      {{ end }}
+      {{- if and .Values.services.rabbitmq.local_setup .Values.ingress.rabbitmqHost }}
+      - {{ .Values.ingress.rabbitmqHost | quote }}
+      {{ end }}
+      secretName: {{ .Values.ssl.tls_secret_name }}
+  {{- else if and .Values.ssl.generateCerts .Values.ssl.createIssuer }}
   tls:
     - hosts:
       - {{ .Values.license.licenseDomain | quote }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -18,6 +18,8 @@ ingress:
   ingress_annotations: { "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }
 
 ssl:
+  tls_secret_name: '' # If you have a custom TLS secret name
+  # If you want to use Let's Encrypt, set createIssuer and generateCerts to true
   createIssuer: false
   issuer: http # Allowed : cloudflare, digitalocean, http
   token: '' # not required for http


### PR DESCRIPTION
Changes:

- Add Support TLS Secret Configuration in Both Plane CE and Plane EE Helm Charts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a custom TLS secret option to SSL settings, enabling users to specify their own TLS secret for flexible ingress and certificate management.
  - Refined conditions for TLS configuration to better differentiate between automatically generated certificates and custom TLS setups.

- **Chores**
  - Updated version numbers for both the CE and Enterprise releases.

- **Documentation**
  - Revised configuration guides and comments to detail the new TLS secret option and provide guidance for Let's Encrypt usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->