### PR TITLE
Rename Plane CE images to dockerhub image repositories

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.1.0
-appVersion: "0.25.3"
+version: 1.1.1
+appVersion: "0.26.0"
 
 home: https://plane.so
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -149,7 +149,7 @@
 | web.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | web.memoryLimit | 1000Mi |  | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | web.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-| web.image| makeplane/plane-frontend |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| web.image| artifacts.plane.so/makeplane/plane-frontend |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | web.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `web`. |  
 | web.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
 
@@ -160,7 +160,7 @@
 | space.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | space.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | space.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-| space.image| makeplane/plane-space|  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| space.image| artifacts.plane.so/makeplane/plane-space|  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | space.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `space`. |
 | space.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
 
@@ -171,7 +171,7 @@
 | admin.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | admin.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | admin.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-| admin.image| makeplane/plane-admin |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| admin.image| artifacts.plane.so/makeplane/plane-admin |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | admin.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `admin`. |
 | admin.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
 
@@ -182,7 +182,7 @@
 | live.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | live.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | live.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-| live.image| makeplane/plane-live |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| live.image| artifacts.plane.so/makeplane/plane-live |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | live.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `live`. |
 | env.live_sentry_dsn |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
 | env.live_sentry_environment |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
@@ -196,7 +196,7 @@
 | api.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | api.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | api.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-| api.image| makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| api.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | api.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `api`. |
 | env.sentry_dsn |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
 | env.sentry_environment |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
@@ -210,7 +210,7 @@
 | worker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | worker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | worker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-| worker.image| makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| worker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 
 ### Beat-Worker deployment
 
@@ -219,7 +219,7 @@
 | beatworker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | beatworker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | beatworker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-| beatworker.image| makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| beatworker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 
 ### Ingress and SSL Setup
 

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -28,7 +28,7 @@ questions:
   label: Frontend Docker Image
   type: string
   required: true
-  default: "makeplane/plane-frontend"
+  default: "artifacts.plane.so/makeplane/plane-frontend"
   group: "Web Setup"
   subquestions:
   - variable: web.pullPolicy
@@ -60,7 +60,7 @@ questions:
   label: Space Docker Image
   type: string
   required: true
-  default: "makeplane/plane-space"
+  default: "artifacts.plane.so/makeplane/plane-space"
   group: "Spaces Setup"
   subquestions:
   - variable: space.pullPolicy
@@ -92,7 +92,7 @@ questions:
   label: Admin Docker Image
   type: string
   required: true
-  default: "makeplane/plane-admin"
+  default: "artifacts.plane.so/makeplane/plane-admin"
   group: "Admin Setup"
   subquestions:
   - variable: admin.pullPolicy
@@ -124,7 +124,7 @@ questions:
   label: Live Docker Image
   type: string
   required: true
-  default: "makeplane/plane-live"
+  default: "artifacts.plane.so/makeplane/plane-live"
   description: "Live Server Setup"
   group: "Live Setup"
   subquestions:
@@ -169,7 +169,7 @@ questions:
   label: Backend Docker Image
   type: string
   required: true
-  default: "makeplane/plane-backend"
+  default: "artifacts.plane.so/makeplane/plane-backend"
   description: "Used by API, Worker, Beat-Worker"
   group: "API Setup"
   subquestions:

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-admin
         imagePullPolicy: {{ .Values.admin.pullPolicy | default "Always" }}
-        image: {{ .Values.admin.image | default "makeplane/plane-frontend" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.admin.image | default "artifacts.plane.so/makeplane/plane-frontend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-api
         imagePullPolicy: {{ .Values.api.pullPolicy | default "Always" }}
-        image: {{ .Values.api.image | default "makeplane/plane-backend" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.api.image | default "artifacts.plane.so/makeplane/plane-backend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-beat-worker
         imagePullPolicy: {{ .Values.beatworker.pullPolicy | default "Always" }}
-        image: {{ .Values.beatworker.image | default "makeplane/plane-backend" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.beatworker.image | default "artifacts.plane.so/makeplane/plane-backend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-live
         imagePullPolicy: {{ .Values.live.pullPolicy | default "Always" }}
-        image: {{ .Values.live.image | default "makeplane/plane-live" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.live.image | default "artifacts.plane.so/makeplane/plane-live" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/migrator.job.yaml
+++ b/charts/plane-ce/templates/workloads/migrator.job.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: {{ .Release.Name }}-api-migrate
-        image: {{ .Values.api.image | default "makeplane/plane-backend" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.api.image | default "artifacts.plane.so/makeplane/plane-backend" }}:{{ .Values.planeVersion }}
         command: 
           - ./bin/docker-entrypoint-migrator.sh
         imagePullPolicy: {{ .Values.api.pullPolicy | default "Always" }}

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-space
         imagePullPolicy: {{ .Values.space.pullPolicy | default "Always" }}
-        image: {{ .Values.space.images | default "makeplane/plane-space" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.space.images | default "artifacts.plane.so/makeplane/plane-space" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-web
         imagePullPolicy: {{ .Values.web.pullPolicy | default "Always" }}
-        image: {{ .Values.web.image | default "makeplane/plane-frontend" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.web.image | default "artifacts.plane.so/makeplane/plane-frontend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-worker
         imagePullPolicy: {{ .Values.worker.pullPolicy | default "Always" }}
-        image: {{ .Values.worker.image | default "makeplane/plane-backend" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.worker.image | default "artifacts.plane.so/makeplane/plane-backend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -73,7 +73,7 @@ web:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-frontend
+  image: artifacts.plane.so/makeplane/plane-frontend
   pullPolicy: Always
   assign_cluster_ip: false
 
@@ -81,7 +81,7 @@ space:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-space
+  image: artifacts.plane.so/makeplane/plane-space
   pullPolicy: Always
   assign_cluster_ip: false
 
@@ -89,7 +89,7 @@ admin:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-admin
+  image: artifacts.plane.so/makeplane/plane-admin
   pullPolicy: Always
   assign_cluster_ip: false
 
@@ -97,7 +97,7 @@ live:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-live
+  image: artifacts.plane.so/makeplane/plane-live
   pullPolicy: Always
   assign_cluster_ip: false
 
@@ -105,7 +105,7 @@ api:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-backend
+  image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
   assign_cluster_ip: false
 
@@ -113,14 +113,14 @@ worker:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-backend
+  image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
 
 beatworker:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
-  image: makeplane/plane-backend
+  image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
 
 external_secrets:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated default Docker image repositories for all Plane components to use the new artifacts.plane.so registry.
  - Incremented Helm chart version to 1.1.1 and application version to 0.26.0.

- **Documentation**
  - Updated documentation to reflect the new default image repository paths for all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->