### PR TITLE
Plane-EE: Add aes secret key

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.9.1"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -267,6 +267,7 @@
 | env.silo_envs.sentry_environment |  |  | Sentry Environment |
 | env.silo_envs.sentry_traces_sample_rate |  |  | Sentry Traces Sample Rate | 
 | env.silo_envs.hmac_secret_key |  &lt;random-32-bit-string&gt; |  | HMAC Secret Key |
+| env.silo_envs.aes_secret_key | "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr" |  | AES Secret Key |
 
   
 ### Worker Deployment

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -249,6 +249,10 @@ questions:
     label: "Silo HMAC Secret Key"
     type: string
     default: ""
+  - variable: env.silo_envs.aes_secret_key
+    label: "Silo AES Secret Key"
+    type: string
+    default: "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr"
   - variable: env.silo_envs.cors_allowed_origins
     label: "Silo CORS Allowed Origins"
     type: string

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-app-secrets
 stringData:
   SECRET_KEY: {{ .Values.env.secret_key | default "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5" | quote }}
+  AES_SECRET_KEY: {{ .Values.env.silo_envs.aes_secret_key | default "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr" | quote }}
   LIVE_SERVER_SECRET_KEY: {{ .Values.env.live_server_secret_key | default "htbqvBJAgpm9bzvf3r4urJer0ENReatceh" | quote }}
 
   {{- if .Values.services.redis.local_setup }}

--- a/charts/plane-enterprise/templates/config-secrets/silo.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/silo.yaml
@@ -15,6 +15,8 @@ stringData:
   SILO_HMAC_SECRET_KEY: {{ randAlphaNum 32 | quote }}
   {{- end }}
 
+  AES_SECRET_KEY: {{ .Values.env.silo_envs.aes_secret_key | default "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr" | quote }}
+
   {{- if .Values.services.postgres.local_setup }}
   DATABASE_URL: "postgresql://{{ .Values.env.pgdb_username }}:{{ .Values.env.pgdb_password }}@{{ .Release.Name }}-pgdb.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}/{{ .Values.env.pgdb_name }}"
   {{- else if .Values.env.pgdb_remote_url }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -204,4 +204,5 @@ env:
     mq_prefetch_count: 1
     request_interval: 400
     hmac_secret_key: ''
+    aes_secret_key: 'dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr'
     cors_allowed_origins: ''


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment variable for silo services to support an AES secret key, with a default value provided.
  - Added configuration options and documentation for the new AES secret key in deployment and setup guides.
  - The AES secret key is now included in the generated Kubernetes secrets for both app and silo services.

- **Chores**
  - Updated the Helm chart version to 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->