### PR TITLE
[INFRA-178] Plane-CE: Add resource requests for Plane CE Helm Chart 

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.1.1
+version: 1.1.2
 appVersion: "0.26.0"
 
 home: https://plane.so

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -149,6 +149,8 @@
 | web.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | web.memoryLimit | 1000Mi |  | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | web.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| web.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+| web.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | web.image| artifacts.plane.so/makeplane/plane-frontend |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | web.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `web`. |  
 | web.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
@@ -160,6 +162,8 @@
 | space.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | space.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | space.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| space.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+| space.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | space.image| artifacts.plane.so/makeplane/plane-space|  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | space.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `space`. |
 | space.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
@@ -171,6 +175,8 @@
 | admin.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | admin.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | admin.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| admin.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+| admin.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | admin.image| artifacts.plane.so/makeplane/plane-admin |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | admin.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `admin`. |
 | admin.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
@@ -182,6 +188,8 @@
 | live.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | live.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | live.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| live.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+| live.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | live.image| artifacts.plane.so/makeplane/plane-live |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | live.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `live`. |
 | env.live_sentry_dsn |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
@@ -196,6 +204,8 @@
 | api.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | api.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | api.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| api.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+| api.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | api.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | api.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `api`. |
 | env.sentry_dsn |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
@@ -210,6 +220,8 @@
 | worker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | worker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | worker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| worker.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+| worker.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | worker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 
 ### Beat-Worker deployment
@@ -219,6 +231,8 @@
 | beatworker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
 | beatworker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
 | beatworker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+| beatworker.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+| beatworker.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | beatworker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 
 ### Ingress and SSL Setup

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -55,6 +55,14 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: false
+  - variable: web.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 50Mi
+  - variable: web.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 50m
 
 - variable: space.image
   label: Space Docker Image
@@ -83,6 +91,14 @@ questions:
     label: "CPU Limit"
     type: string
     default: 500m
+  - variable: space.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 50Mi
+  - variable: space.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 50m
   - variable: space.assign_cluster_ip
     label: "Assign Cluster IP"
     type: boolean
@@ -119,7 +135,14 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: true
-
+  - variable: admin.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 50Mi
+  - variable: admin.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 50m
 - variable: live.image
   label: Live Docker Image
   type: string
@@ -152,6 +175,14 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: false
+  - variable: live.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 50Mi
+  - variable: live.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 50m
   - variable: env.live_sentry_dsn
     label: "Live Sentry DSN"
     type: string
@@ -197,6 +228,14 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: false
+  - variable: api.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 50Mi
+  - variable: api.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 50m
   - variable: env.cors_allowed_origins
     label: "CORS Allowed Origins"
     type: string
@@ -233,7 +272,14 @@ questions:
     label: "CPU Limit"
     type: string
     default: 500m
-
+  - variable: worker.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 50Mi
+  - variable: worker.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 50m
 - variable: beatworker.replicas
   label: "Default Replica Count"
   type: int
@@ -248,7 +294,14 @@ questions:
     label: "CPU Limit"
     type: string
     default: 500m
-
+  - variable: beatworker.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 50Mi
+  - variable: beatworker.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 50m  
 - variable: redis.local_setup
   label: "Install Redis"
   type: boolean

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -46,8 +46,8 @@ spec:
         tty: true
         resources:
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: {{ .Values.admin.memoryRequest | default "50Mi" | quote }}
+            cpu: {{ .Values.admin.cpuRequest | default "50m" | quote }}
           limits:
             memory: {{ .Values.admin.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.admin.cpuLimit | default "500m" | quote}}

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -46,8 +46,8 @@ spec:
         tty: true
         resources:
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: {{ .Values.api.memoryRequest | default "50Mi" | quote }}
+            cpu: {{ .Values.api.cpuRequest | default "50m" | quote }}
           limits:
             memory: {{ .Values.api.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.api.cpuLimit | default "500m" | quote}}

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -24,8 +24,8 @@ spec:
         tty: true
         resources:
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: {{ .Values.beatworker.memoryRequest | default "50Mi" | quote }}
+            cpu: {{ .Values.beatworker.cpuRequest | default "50m" | quote }}
           limits:
             memory: {{ .Values.beatworker.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.beatworker.cpuLimit | default "500m" | quote}}

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -46,8 +46,8 @@ spec:
         tty: true
         resources:
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: {{ .Values.live.memoryRequest | default "50Mi" | quote }}
+            cpu: {{ .Values.live.cpuRequest | default "50m" | quote }}
           limits:
             memory: {{ .Values.live.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.live.cpuLimit | default "500m" | quote}}

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-space
         imagePullPolicy: {{ .Values.space.pullPolicy | default "Always" }}
-        image: {{ .Values.space.images | default "artifacts.plane.so/makeplane/plane-space" }}:{{ .Values.planeVersion }}
+        image: {{ .Values.space.image | default "artifacts.plane.so/makeplane/plane-space" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true
         resources:

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -49,8 +49,8 @@ spec:
             memory: {{ .Values.space.memoryRequest | default "50Mi" | quote }}
             cpu: {{ .Values.space.cpuRequest | default "50m" | quote }}
           limits:
-            memory: {{ .Values.web.memoryLimit  | default "1000Mi" | quote }}
-            cpu: {{ .Values.web.cpuLimit | default "500m" | quote}}
+            memory: {{ .Values.space.memoryLimit  | default "1000Mi" | quote }}
+            cpu: {{ .Values.space.cpuLimit | default "500m" | quote}}
         command:
           - node
         args:

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -46,8 +46,8 @@ spec:
         tty: true
         resources:
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: {{ .Values.space.memoryRequest | default "50Mi" | quote }}
+            cpu: {{ .Values.space.cpuRequest | default "50m" | quote }}
           limits:
             memory: {{ .Values.web.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.web.cpuLimit | default "500m" | quote}}

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -46,8 +46,8 @@ spec:
         tty: true
         resources:
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: {{ .Values.web.memoryRequest | default "50Mi" | quote }}
+            cpu: {{ .Values.web.cpuRequest | default "50m" | quote }}
           limits:
             memory: {{ .Values.web.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.web.cpuLimit | default "500m" | quote}}

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -24,8 +24,8 @@ spec:
         tty: true
         resources:
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: {{ .Values.worker.memoryRequest | default "50Mi" | quote }}
+            cpu: {{ .Values.worker.cpuRequest | default "50m" | quote }}
           limits:
             memory: {{ .Values.worker.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.worker.cpuLimit | default "500m" | quote}}

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -73,6 +73,8 @@ web:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
+  cpuRequest: 50m
+  memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-frontend
   pullPolicy: Always
   assign_cluster_ip: false
@@ -81,6 +83,8 @@ space:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
+  cpuRequest: 50m
+  memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-space
   pullPolicy: Always
   assign_cluster_ip: false
@@ -89,6 +93,8 @@ admin:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
+  cpuRequest: 50m
+  memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-admin
   pullPolicy: Always
   assign_cluster_ip: false
@@ -97,6 +103,8 @@ live:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
+  cpuRequest: 50m
+  memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-live
   pullPolicy: Always
   assign_cluster_ip: false
@@ -105,6 +113,8 @@ api:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
+  cpuRequest: 50m
+  memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
   assign_cluster_ip: false
@@ -113,6 +123,8 @@ worker:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
+  cpuRequest: 50m
+  memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
 
@@ -120,6 +132,8 @@ beatworker:
   replicas: 1
   memoryLimit: 1000Mi
   cpuLimit: 500m
+  cpuRequest: 50m
+  memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Added configurable CPU and memory resource request options for all major service components, allowing users to customize resource allocation for web, space, admin, live, api, worker, and beatworker components through the Helm chart interface

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable CPU and memory resource requests for all major components, allowing users to specify minimum resource allocations in addition to existing limits.

- **Documentation**
  - Updated documentation to describe the new resource request options available for each component.

- **Chores**
  - Incremented Helm chart version to 1.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->