### PR TITLE
Plane-EE: Update Plane Version to 1.12.0 

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.1.2
+version: 1.1.3
 appVersion: "0.26.1"
 
 home: https://plane.so

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,11 +5,10 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.2.5
-appVersion: "1.11.0"
+version: 1.2.6
+appVersion: "1.12.0"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png
 sources:
-  - https://github.com/makeplane/plane-ee
-
+- https://github.com/makeplane/plane-ee

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -11,7 +11,7 @@
       Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
       ```bash
-      PLANE_VERSION=v1.11.0 # or the last released version
+      PLANE_VERSION=v1.12.0 # or the last released version
       DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
       ```
 
@@ -65,7 +65,7 @@
           ```
 
           Make sure you set the minimum required values as below.
-          - `planeVersion: v1.11.0 <or the last released version>`
+          - `planeVersion: v1.12.0 <or the last released version>`
           - `license.licenseDomain: <The domain you have specified to host Plane>`
           - `ingress.enabled: <true | false>`
           - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
@@ -100,7 +100,7 @@
 
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
-| planeVersion | v1.11.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
+| planeVersion | v1.12.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -20,7 +20,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v1.11.0
+  default: v1.12.0
   required: true
   group: "Docker Registry"
   subquestions:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v1.11.0
+planeVersion: v1.12.0
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chart and app versions for Plane CE and Plane Enterprise Helm charts.
  * Updated default Plane version to v1.12.0 in configuration files and documentation.
  * Adjusted formatting of the sources field in the Plane Enterprise chart metadata.
* **Documentation**
  * Updated documentation to reference the new default Plane version (v1.12.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->