### PR TITLE
[INFRA-202] Plane-EE: Remove Commands/args from deployment files 

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.2.6
-appVersion: "1.12.0"
+version: 1.2.7
+appVersion: "1.12.1"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -6,7 +6,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 type: application
 
 version: 1.2.7
-appVersion: "1.12.1"
+appVersion: "1.12.0"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.2.7
-appVersion: "1.12.1"
+version: 1.2.8
+appVersion: "1.13.0"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -11,7 +11,7 @@
       Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
       ```bash
-      PLANE_VERSION=v1.12.1 # or the last released version
+      PLANE_VERSION=v1.13.0 # or the last released version
       DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
       ```
 
@@ -65,7 +65,7 @@
           ```
 
           Make sure you set the minimum required values as below.
-          - `planeVersion: v1.12.1 <or the last released version>`
+          - `planeVersion: v1.13.0 <or the last released version>`
           - `license.licenseDomain: <The domain you have specified to host Plane>`
           - `ingress.enabled: <true | false>`
           - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
@@ -100,7 +100,7 @@
 
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
-| planeVersion | v1.12.1 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
+| planeVersion | v1.13.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -20,7 +20,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v1.12.1
+  default: v1.13.0
   required: true
   group: "Docker Registry"
   subquestions:

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -52,11 +52,6 @@ spec:
           limits:
             memory: {{ .Values.services.admin.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.admin.cpuLimit | default "500m" | quote}}
-        command:
-          - node
-        args:
-          - admin/server.js
-          - admin
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
 

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -52,8 +52,6 @@ spec:
           limits:
             memory: {{ .Values.services.api.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.api.cpuLimit | default "500m" | quote}}
-        command:
-          - ./bin/docker-entrypoint-api-ee.sh
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-app-vars

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -52,10 +52,6 @@ spec:
           limits:
             memory: {{ .Values.services.live.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.live.cpuLimit | default "500m" | quote}}
-        command:
-          - node
-        args:
-          - live/dist/start.js
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-live-vars

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -75,10 +75,6 @@ spec:
           limits:
             memory: {{ .Values.services.silo.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.silo.cpuLimit | default "500m" | quote}}
-        command:
-          - node
-        args:
-          - silo/start.cjs
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-silo-vars

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -52,11 +52,6 @@ spec:
           limits:
             memory: {{ .Values.services.space.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.space.cpuLimit | default "500m" | quote}}
-        command:
-          - node
-        args:
-          - space/server.js
-          - space
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
 

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -52,11 +52,6 @@ spec:
           limits:
             memory: {{ .Values.services.web.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.web.cpuLimit | default "500m" | quote}}
-        command:
-          - node
-        args:
-          - web/server.js
-          - web
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
 

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v1.12.1
+planeVersion: v1.13.0
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION
Changes:

- Remove Commands/args from deployment files - api, web, admin, live, silo, and space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated deployment configurations to use the default entrypoint and command defined in container images for all workloads, removing explicit command and argument overrides. This streamlines container startup behavior across services. No changes were made to other deployment settings.
* **Chores**
  * Updated Plane chart and documentation to version 1.13.0, reflecting the latest application release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->