### PR TITLE
Plane-EE: Add Horizontal Pod Autoscaler (HPA) to Plane Enterprise Deployments

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.2.7
+version: 1.3.0
 appVersion: "1.12.1"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -5,3 +5,12 @@
 {{- define "hashString" -}}
 {{- printf "%s%s%s%s" .Values.license.licenseServer .Values.license.licenseDomain .Release.Namespace .Release.Name | sha256sum  -}}
 {{- end -}}
+
+{{- define "enable.hpa" -}}
+{{- $metrics := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "system:metrics-server" }}
+{{- if not $metrics }}
+false
+{{- else }}
+true
+{{- end }}
+{{- end }}

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -61,3 +61,40 @@ spec:
       serviceAccountName: {{ .Release.Name }}-srv-account
 
 ---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-admin-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-admin-wl
+  minReplicas: {{ .Values.services.admin.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.admin.autoscaling.maxReplicas }}
+  {{- if or .Values.services.admin.autoscaling.targetCPUUtilizationPercentage .Values.services.admin.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.admin.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.admin.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.admin.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.admin.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -81,4 +81,42 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
+
+---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-api-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-api-wl
+  minReplicas: {{ .Values.services.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.api.autoscaling.maxReplicas }}
+  {{- if or .Values.services.api.autoscaling.targetCPUUtilizationPercentage .Values.services.api.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 ---

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -51,3 +51,40 @@ spec:
       serviceAccountName: {{ .Release.Name }}-srv-account
 
 ---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-beat-worker-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-beat-worker-wl
+  minReplicas: {{ .Values.services.beatworker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.beatworker.autoscaling.maxReplicas }}
+  {{- if or .Values.services.beatworker.autoscaling.targetCPUUtilizationPercentage .Values.services.beatworker.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.beatworker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.beatworker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.beatworker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.beatworker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -67,3 +67,40 @@ spec:
       serviceAccountName: {{ .Release.Name }}-srv-account
 
 ---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-live-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-live-wl
+  minReplicas: {{ .Values.services.live.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.live.autoscaling.maxReplicas }}
+  {{- if or .Values.services.live.autoscaling.targetCPUUtilizationPercentage .Values.services.live.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.live.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.live.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.live.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.live.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -88,5 +88,43 @@ spec:
               optional: false
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
+
+---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-silo-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-silo-wl
+  minReplicas: {{ .Values.services.silo.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.silo.autoscaling.maxReplicas }}
+  {{- if or .Values.services.silo.autoscaling.targetCPUUtilizationPercentage .Values.services.silo.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.silo.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.silo.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.silo.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.silo.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 ---
 {{- end }}

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -61,3 +61,40 @@ spec:
       serviceAccountName: {{ .Release.Name }}-srv-account
 
 ---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-space-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-space-wl
+  minReplicas: {{ .Values.services.space.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.space.autoscaling.maxReplicas }}
+  {{- if or .Values.services.space.autoscaling.targetCPUUtilizationPercentage .Values.services.space.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.space.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.space.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.space.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.space.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -61,3 +61,40 @@ spec:
       serviceAccountName: {{ .Release.Name }}-srv-account
 
 ---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-web-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-web-wl
+  minReplicas: {{ .Values.services.web.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.web.autoscaling.maxReplicas }}
+  {{- if or .Values.services.web.autoscaling.targetCPUUtilizationPercentage .Values.services.web.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.web.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.web.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.web.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.web.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -51,3 +51,40 @@ spec:
       serviceAccountName: {{ .Release.Name }}-srv-account
 
 ---
+{{- if eq (include "enable.hpa" . | trim) "true" }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-worker-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-worker-wl
+  minReplicas: {{ .Values.services.worker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.services.worker.autoscaling.maxReplicas }}
+  {{- if or .Values.services.worker.autoscaling.targetCPUUtilizationPercentage .Values.services.worker.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.services.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.services.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -77,6 +77,11 @@ services:
     image: artifacts.plane.so/makeplane/web-commercial
     pullPolicy: Always
     assign_cluster_ip: false
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
 
   monitor:
     memoryLimit: 1000Mi
@@ -97,6 +102,11 @@ services:
     image: artifacts.plane.so/makeplane/space-commercial
     pullPolicy: Always
     assign_cluster_ip: false
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
 
   admin:
     replicas: 1
@@ -107,6 +117,11 @@ services:
     image: artifacts.plane.so/makeplane/admin-commercial
     pullPolicy: Always
     assign_cluster_ip: false
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
 
   live:
     replicas: 1
@@ -117,6 +132,11 @@ services:
     image: artifacts.plane.so/makeplane/live-commercial
     pullPolicy: Always
     assign_cluster_ip: false
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
 
   api:
     replicas: 1
@@ -127,6 +147,11 @@ services:
     image: artifacts.plane.so/makeplane/backend-commercial
     pullPolicy: Always
     assign_cluster_ip: false
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
 
   worker:
     replicas: 1
@@ -134,12 +159,22 @@ services:
     cpuLimit: 500m
     memoryRequest: 50Mi
     cpuRequest: 50m
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
   beatworker:
     replicas: 1
     memoryLimit: 1000Mi
     cpuLimit: 500m
     memoryRequest: 50Mi
     cpuRequest: 50m
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
   silo:
     enabled: true
     replicas: 1
@@ -150,6 +185,11 @@ services:
     image: artifacts.plane.so/makeplane/silo-commercial
     pullPolicy: Always
     assign_cluster_ip: false
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70
     connectors:
       slack:
         enabled: false
@@ -176,7 +216,7 @@ services:
     cpuRequest: 50m
     image: artifacts.plane.so/makeplane/email-commercial
     pullPolicy: Always
-
+    
 external_secrets:
   # Name of the existing Kubernetes Secret resource; see README for more details
   rabbitmq_existingSecret: ''


### PR DESCRIPTION
### Description

- Configured HPA with default CPU threshold and min/max replica limits for plane-enterprise helm chart