### PR TITLE
feat: Add airgapped support to Plane-Enterprise configuration (#148)

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.3.2
+version: 1.3.3
 appVersion: "1.13.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -86,21 +86,13 @@
           ```
 
 ## Available customizations
-
-<!-- ### Docker registry
-
-| Setting | Default | Required | Description |
-|---|:---:|:---:|---|
-| dockerRegistry.enabled | false |  | Plane uses a private Docker registry which needs authenticated login. This must be set to `true` to install Plane Enterprise. |
-| dockerRegistry.registry |  registry.plane.tools| Yes | The host that will serve the required Docker images; Don't change this. |
-| dockerRegistry.loginid |  | Yes | Sets the `loginid` for the Docker registry. This is the same as the REG_USER_ID value on prime. plane.so |
-| dockerRegistry.password |  | Yes | Sets the `password` for the Docker registry. This is the same as the REG_PASSWORD value on prime.plane.so|
-   -->
+   
 ### License
 
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
 | planeVersion | v1.13.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
+| airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -62,6 +62,10 @@ data:
   LIVE_BASE_URL: "http://{{ .Release.Name }}-live.{{ .Release.Namespace }}.svc.cluster.local:3000/"
   LIVE_BASE_PATH: "/live"
 
+  {{- if .Values.airgapped.enabled }}
+  IS_AIRGAPPED: "1"
+  {{- end }}
+
   {{- if eq .Values.env.cors_allowed_origins "*"}}
   CORS_ALLOWED_ORIGINS: "*"
   {{- else if .Values.env.cors_allowed_origins }}

--- a/charts/plane-enterprise/templates/config-secrets/monitor.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/monitor.yaml
@@ -11,3 +11,6 @@ data:
   DEPLOY_PLATFORM: "KUBERNETES"
   API_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/"
   API_HOSTNAME: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/"
+  {{- if .Values.airgapped.enabled }}
+  IS_AIRGAPPED: "1"
+  {{- end }}

--- a/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
@@ -42,6 +42,12 @@ spec:
         name: {{ .Release.Name }}-monitor
         stdin: true
         tty: true
+        {{- if .Values.airgapped.enabled }}
+        command:
+          - prime-monitor
+        args:
+          - start-airgapped
+        {{- end }}
         resources:
           requests:
             memory: {{ .Values.services.monitor.memoryRequest | default "50Mi" | quote }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -10,6 +10,9 @@ license:
   licenseServer: https://prime.plane.so
   licenseDomain: 'plane.example.com'
 
+airgapped: 
+  enabled: false
+
 ingress:
   enabled: true
   minioHost: ''


### PR DESCRIPTION
* feat: Add airgapped support to Plane-Enterprise configuration
* Introduced `airgapped` configuration option in values.yaml.
* Updated app-env.yaml to include IS_AIRGAPPED environment variable.
* Modified monitor.stateful.yaml to conditionally start the airgapped monitor command based on the new configuration.
* Set `airgapped.enabled` to false in values.yaml.
* Adjusted README.md to reflect the new airgapped configuration option.

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [X] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [X] Documentation update

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
[Airgapped docs](https://developers.plane.so/self-hosting/methods/airgapped-edition )