### PR TITLE
chore: Add s3 custom CA airgapped support

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -6,7 +6,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 type: application
 
 version: 1.4.0
-appVersion: "v1.14.0-rc6"
+appVersion: "v1.14.1"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -6,7 +6,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 type: application
 
 version: 1.4.0
-appVersion: "1.14.0"
+appVersion: "v1.14.0-rc6"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -93,8 +93,8 @@
 |---|:---:|:---:|---|
 | planeVersion | v1.14.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
 | airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
-| airgapped.s3CrtFileLocation | "/s3-custom-ca/s3-custom-ca.crt" | No | Path inside the container to the CA certificate file used for S3 (Boto). Effective when `airgapped.enabled=true` and `airgapped.s3SecretName` is set. |
-| airgapped.s3SecretName | "" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3CrtFileLocation` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. | 
+| airgapped.s3CrtFileLocation | "/s3-custom-ca/s3-custom-ca.crt" | No | Path inside the container to the CA certificate file used for S3 (Boto). Effective when `airgapped.enabled=true` and `airgapped.s3SecretName` is set. This certificate is used to connect to S3 solely and will disregard other Amazon CAs. |
+| airgapped.s3SecretName | "" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3CrtFileLocation` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. Applying this secret looks like: `kubectl -n plane create secret generic plane-s3-ca \ --from-file=s3-custom-ca.crt=/path/to/your/ca.crt` | 
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -93,6 +93,8 @@
 |---|:---:|:---:|---|
 | planeVersion | v1.14.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
 | airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
+| airgapped.s3CrtFileLocation | "" | No | If specified, overrides the CA that is used to communicate with S3. Specifies the location in the container where the new .crt file lies |
+| airgapped.s3SecretName | "" | No | Specifies the secret where to copy the overriding .crt file from for use in overriding s3's native CA | 
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -100,8 +100,8 @@
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
 | airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
-| airgapped.s3SecretName | "s3-custom-ca" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3SecretKey` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. Applying this secret looks like: `kubectl -n plane create secret generic plane-s3-ca \ --from-file=s3-custom-ca.crt=/path/to/your/ca.crt` | 
-| airgapped.s3SecretKey | "s3-custom-ca.crt" | No | Key name of the secret to load the Custom Root CA from `airgapped.s3SecretName` |
+| airgapped.s3SecretName | "" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3SecretKey`. Used to override S3’s CA when `airgapped.enabled=true`. Applying this secret looks like: `kubectl -n plane create secret generic plane-s3-ca \ --from-file=s3-custom-ca.crt=/path/to/your/ca.crt` | 
+| airgapped.s3SecretKey | "" | No | Key name of the secret to load the Custom Root CA from `airgapped.s3SecretName` |
 
 ### Postgres
 

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -93,8 +93,8 @@
 |---|:---:|:---:|---|
 | planeVersion | v1.14.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
 | airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
-| airgapped.s3CrtFileLocation | "/s3-custom-ca/s3-custom-ca.crt" | No | If specified, overrides the CA that is used to communicate with S3. Specifies the location in the container where the new .crt file lies |
-| airgapped.s3SecretName | "" | No | Specifies the secret where to copy the overriding .crt file from for use in overriding s3's native CA for the s3 client. | 
+| airgapped.s3CrtFileLocation | "/s3-custom-ca/s3-custom-ca.crt" | No | Path inside the container to the CA certificate file used for S3 (Boto). Effective when `airgapped.enabled=true` and `airgapped.s3SecretName` is set. |
+| airgapped.s3SecretName | "" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3CrtFileLocation` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. | 
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -92,10 +92,16 @@
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|
 | planeVersion | v1.14.1 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
-| airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
-| airgapped.s3CrtFileLocation | "/s3-custom-ca/s3-custom-ca.crt" | No | Path inside the container to the CA certificate file used for S3 (Boto). Effective when `airgapped.enabled=true` and `airgapped.s3SecretName` is set. This certificate is used to connect to S3 solely and will disregard other Amazon CAs. |
-| airgapped.s3SecretName | "" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3CrtFileLocation` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. Applying this secret looks like: `kubectl -n plane create secret generic plane-s3-ca \ --from-file=s3-custom-ca.crt=/path/to/your/ca.crt` | 
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
+
+
+### Air-gapped Settings
+
+| Setting | Default | Required | Description |
+|---|:---:|:---:|---|
+| airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
+| airgapped.s3SecretName | "s3-custom-ca" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3SecretKey` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. Applying this secret looks like: `kubectl -n plane create secret generic plane-s3-ca \ --from-file=s3-custom-ca.crt=/path/to/your/ca.crt` | 
+| airgapped.s3SecretKey | "s3-custom-ca.crt" | No | Key name of the secret to load the Custom Root CA from `airgapped.s3SecretName` |
 
 ### Postgres
 

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -93,8 +93,8 @@
 |---|:---:|:---:|---|
 | planeVersion | v1.14.0 | Yes |  Specifies the version of Plane to be deployed. Copy this from prime.plane.so. |
 | airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
-| airgapped.s3CrtFileLocation | "" | No | If specified, overrides the CA that is used to communicate with S3. Specifies the location in the container where the new .crt file lies |
-| airgapped.s3SecretName | "" | No | Specifies the secret where to copy the overriding .crt file from for use in overriding s3's native CA | 
+| airgapped.s3CrtFileLocation | "/s3-custom-ca/s3-custom-ca.crt" | No | If specified, overrides the CA that is used to communicate with S3. Specifies the location in the container where the new .crt file lies |
+| airgapped.s3SecretName | "" | No | Specifies the secret where to copy the overriding .crt file from for use in overriding s3's native CA for the s3 client. | 
 | license.licenseDomain | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Postgres

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -80,6 +80,22 @@ questions:
     type: string
     required: true
 
+- variable: airgapped.enabled
+  label: "Airgapped Enabled"
+  type: boolean
+  default: false
+  group: "License Setup"
+  show_subquestion_if: true
+  subquestions:
+  - variable: airgapped.s3SecretName
+    label: "S3 Secret Name"
+    type: string
+    default: ""
+  - variable: airgapped.s3SecretKey
+    label: "S3 Secret Key"
+    type: string
+    default: ""
+
 - variable: services.web.pullPolicy
   label: "Web Pull Policy"
   type: enum

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -49,6 +49,7 @@ data:
 
   API_KEY_RATE_LIMIT: {{ .Values.env.api_key_rate_limit | default "60/minute" | quote }}
   MINIO_ENDPOINT_SSL: {{ .Values.services.minio.env.minio_endpoint_ssl | default false | ternary "1" "0" | quote }}
+  USE_STORAGE_PROXY: {{ .Values.services.minio.use_storage_proxy | default false | ternary "1" "0" | quote }}
   INTAKE_EMAIL_DOMAIN: {{ .Values.env.email_service_envs.smtp_domain | default "" | quote }}
 
   {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -33,7 +33,7 @@ stringData:
   {{ end }}
 
   {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName .Values.airgapped.s3SecretKey }}
-  AWS_CA_BUNDLE: "/s3-custom-ca/{{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}"
+  AWS_CA_BUNDLE: "/s3-custom-ca/{{ .Values.airgapped.s3SecretKey }}"
   {{- end }}
 
 {{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -51,6 +51,10 @@ data:
   MINIO_ENDPOINT_SSL: {{ .Values.services.minio.env.minio_endpoint_ssl | default false | ternary "1" "0" | quote }}
   INTAKE_EMAIL_DOMAIN: {{ .Values.env.email_service_envs.smtp_domain | default "" | quote }}
 
+  {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+  AWS_CA_BUNDLE: {{ .Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt" | quote }}
+  {{- end }}
+
   SENTRY_DSN: {{ .Values.env.sentry_dsn | default "" | quote}}
   SENTRY_ENVIRONMENT: {{ .Values.env.sentry_environment | default "" | quote}}
   DEBUG: "0"

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -31,6 +31,11 @@ stringData:
   {{- else }}
   AMQP_URL: ""
   {{ end }}
+
+  {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName .Values.airgapped.s3SecretKey }}
+  AWS_CA_BUNDLE: "/s3-custom-ca/{{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}"
+  {{- end }}
+
 {{- end }}
 ---
 
@@ -49,12 +54,8 @@ data:
 
   API_KEY_RATE_LIMIT: {{ .Values.env.api_key_rate_limit | default "60/minute" | quote }}
   MINIO_ENDPOINT_SSL: {{ .Values.services.minio.env.minio_endpoint_ssl | default false | ternary "1" "0" | quote }}
-  USE_STORAGE_PROXY: {{ .Values.services.minio.use_storage_proxy | default false | ternary "1" "0" | quote }}
+  USE_STORAGE_PROXY: {{ .Values.env.use_storage_proxy | default false | ternary "1" "0" | quote }}
   INTAKE_EMAIL_DOMAIN: {{ .Values.env.email_service_envs.smtp_domain | default "" | quote }}
-
-  {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
-  AWS_CA_BUNDLE: {{ .Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt" | quote }}
-  {{- end }}
 
   SENTRY_DSN: {{ .Values.env.sentry_dsn | default "" | quote}}
   SENTRY_ENVIRONMENT: {{ .Values.env.sentry_environment | default "" | quote}}

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -39,8 +39,8 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
-      {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
       volumes:
+      {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
         - name: s3-custom-ca
           secret:
             secretName: {{ .Values.airgapped.s3SecretName }}
@@ -48,6 +48,55 @@ spec:
               - key: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
                 path: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
       {{- end }}
+        - name: ca-certificates
+          emptyDir: {}
+      initContainers:
+      - name: install-ca-certs
+        image: ubuntu:22.04
+        command:
+          - /bin/bash
+          - -c
+          - |
+            set -e
+            echo "Installing custom CA certificates..."
+            
+            # Install ca-certificates package and create directories
+            apt-get update && apt-get install -y ca-certificates
+            mkdir -p /shared-certs
+            
+            # Copy existing system CA certificates to shared directory
+            if [ -d /etc/ssl/certs ]; then
+              cp -r /etc/ssl/certs/* /shared-certs/ 2>/dev/null || true
+            fi
+            
+            # Ensure ca-certificates directory exists
+            mkdir -p /usr/local/share/ca-certificates
+            
+            # Install custom S3 CA if available
+            {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+            S3_CERT_FILE="{{ (.Values.airgapped.s3CrtFileLocation | default "s3-custom-ca.crt") | base }}"
+            if [ -f "/s3-custom-ca/$S3_CERT_FILE" ]; then
+              echo "Installing S3 custom CA certificate..."
+              cp "/s3-custom-ca/$S3_CERT_FILE" /usr/local/share/ca-certificates/s3-custom-ca.crt
+              cp "/s3-custom-ca/$S3_CERT_FILE" /shared-certs/s3-custom-ca.crt
+            fi
+            {{- end }}
+            
+            # Update CA certificates
+            update-ca-certificates
+            
+            # Copy updated system certificates to shared volume
+            cp -r /etc/ssl/certs/* /shared-certs/ 2>/dev/null || true
+            
+            echo "CA certificates installed successfully"
+        volumeMounts:
+        {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+          - name: s3-custom-ca
+            mountPath: /s3-custom-ca
+            readOnly: true
+        {{- end }}
+          - name: ca-certificates
+            mountPath: /shared-certs
       containers:
       - name: {{ .Release.Name }}-api
         imagePullPolicy: {{ .Values.services.api.pullPolicy | default "Always" }}
@@ -61,11 +110,20 @@ spec:
           limits:
             memory: {{ .Values.services.api.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.api.cpuLimit | default "500m" | quote}}
-        {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
         volumeMounts:
-          - name: s3-custom-ca
-            mountPath: /s3-custom-ca
+          - name: ca-certificates
+            mountPath: /etc/ssl/certs
             readOnly: true
+        {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+        env:
+          - name: SSL_CERT_FILE
+            value: "/etc/ssl/certs/ca-certificates.crt"
+          - name: SSL_CERT_DIR
+            value: "/etc/ssl/certs"
+          - name: REQUESTS_CA_BUNDLE
+            value: "/etc/ssl/certs/ca-certificates.crt"
+          - name: CURL_CA_BUNDLE
+            value: "/etc/ssl/certs/ca-certificates.crt"
         {{- end }}
         command:
           - ./bin/docker-entrypoint-api-ee.sh

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -61,7 +61,7 @@ spec:
           limits:
             memory: {{ .Values.services.api.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.api.cpuLimit | default "500m" | quote}}
-        {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+        {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName .Values.airgapped.s3SecretKey }}
         volumeMounts:
           - name: s3-custom-ca
             mountPath: /s3-custom-ca

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -48,55 +48,6 @@ spec:
               - key: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
                 path: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
       {{- end }}
-        - name: ca-certificates
-          emptyDir: {}
-      initContainers:
-      - name: install-ca-certs
-        image: ubuntu:22.04
-        command:
-          - /bin/bash
-          - -c
-          - |
-            set -e
-            echo "Installing custom CA certificates..."
-            
-            # Install ca-certificates package and create directories
-            apt-get update && apt-get install -y ca-certificates
-            mkdir -p /shared-certs
-            
-            # Copy existing system CA certificates to shared directory
-            if [ -d /etc/ssl/certs ]; then
-              cp -r /etc/ssl/certs/* /shared-certs/ 2>/dev/null || true
-            fi
-            
-            # Ensure ca-certificates directory exists
-            mkdir -p /usr/local/share/ca-certificates
-            
-            # Install custom S3 CA if available
-            {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
-            S3_CERT_FILE="{{ (.Values.airgapped.s3CrtFileLocation | default "s3-custom-ca.crt") | base }}"
-            if [ -f "/s3-custom-ca/$S3_CERT_FILE" ]; then
-              echo "Installing S3 custom CA certificate..."
-              cp "/s3-custom-ca/$S3_CERT_FILE" /usr/local/share/ca-certificates/s3-custom-ca.crt
-              cp "/s3-custom-ca/$S3_CERT_FILE" /shared-certs/s3-custom-ca.crt
-            fi
-            {{- end }}
-            
-            # Update CA certificates
-            update-ca-certificates
-            
-            # Copy updated system certificates to shared volume
-            cp -r /etc/ssl/certs/* /shared-certs/ 2>/dev/null || true
-            
-            echo "CA certificates installed successfully"
-        volumeMounts:
-        {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
-          - name: s3-custom-ca
-            mountPath: /s3-custom-ca
-            readOnly: true
-        {{- end }}
-          - name: ca-certificates
-            mountPath: /shared-certs
       containers:
       - name: {{ .Release.Name }}-api
         imagePullPolicy: {{ .Values.services.api.pullPolicy | default "Always" }}
@@ -110,11 +61,11 @@ spec:
           limits:
             memory: {{ .Values.services.api.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.api.cpuLimit | default "500m" | quote}}
-        volumeMounts:
-          - name: ca-certificates
-            mountPath: /etc/ssl/certs
-            readOnly: true
         {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+        volumeMounts:
+          - name: s3-custom-ca
+            mountPath: /s3-custom-ca
+            readOnly: true
         env:
           - name: SSL_CERT_FILE
             value: "/etc/ssl/certs/ca-certificates.crt"
@@ -126,7 +77,32 @@ spec:
             value: "/etc/ssl/certs/ca-certificates.crt"
         {{- end }}
         command:
-          - ./bin/docker-entrypoint-api-ee.sh
+          - /bin/bash
+          - -c
+          - |
+            set -e
+            
+            {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+            echo "Installing custom CA certificates..."
+            
+            # Ensure ca-certificates directory exists
+            mkdir -p /usr/local/share/ca-certificates
+            
+            # Install custom S3 CA if available
+            S3_CERT_FILE="{{ (.Values.airgapped.s3CrtFileLocation | default "s3-custom-ca.crt") | base }}"
+            if [ -f "/s3-custom-ca/$S3_CERT_FILE" ]; then
+              echo "Installing S3 custom CA certificate..."
+              cp "/s3-custom-ca/$S3_CERT_FILE" /usr/local/share/ca-certificates/s3-custom-ca.crt
+              # Update CA certificates
+              update-ca-certificates
+              echo "CA certificates installed successfully"
+            else
+              echo "No custom S3 CA certificate found, skipping..."
+            fi
+            {{- end }}
+            
+            # Start the API
+            exec ./bin/docker-entrypoint-api-ee.sh
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-app-vars

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -39,8 +39,8 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
-      volumes:
       {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName .Values.airgapped.s3SecretKey }}
+      volumes:
         - name: s3-custom-ca
           secret:
             secretName: {{ .Values.airgapped.s3SecretName }}

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - name: s3-custom-ca
           secret:
             secretName: {{ .Values.airgapped.s3SecretName }}
+            items:
+              - key: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
+                path: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-api

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -45,8 +45,8 @@ spec:
           secret:
             secretName: {{ .Values.airgapped.s3SecretName }}
             items:
-              - key: {{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}
-                path: {{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}
+              - key: {{ .Values.airgapped.s3SecretKey }}
+                path: {{ .Values.airgapped.s3SecretKey }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-api
@@ -89,7 +89,7 @@ spec:
             mkdir -p /usr/local/share/ca-certificates
             
             # Install custom S3 CA if available
-            S3_CERT_FILE="{{ (.Values.airgapped.s3SecretKey | default "s3-custom-ca.crt") | base }}"
+            S3_CERT_FILE="{{ .Values.airgapped.s3SecretKey }}"
             if [ -f "/s3-custom-ca/$S3_CERT_FILE" ]; then
               echo "Installing S3 custom CA certificate..."
               cp "/s3-custom-ca/$S3_CERT_FILE" "/usr/local/share/ca-certificates/$S3_CERT_FILE"

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -45,8 +45,8 @@ spec:
           secret:
             secretName: {{ .Values.airgapped.s3SecretName }}
             items:
-              - key: "/s3-custom-ca/{{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}"
-                path: "/s3-custom-ca/{{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}"
+              - key: {{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}
+                path: {{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-api

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -40,13 +40,13 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       volumes:
-      {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+      {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName .Values.airgapped.s3SecretKey }}
         - name: s3-custom-ca
           secret:
             secretName: {{ .Values.airgapped.s3SecretName }}
             items:
-              - key: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
-                path: {{ (.Values.airgapped.s3CrtFileLocation | default "/s3-custom-ca/s3-custom-ca.crt") | base }}
+              - key: "/s3-custom-ca/{{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}"
+                path: "/s3-custom-ca/{{ .Values.airgapped.s3SecretKey | default "s3-custom-ca.crt" }}"
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-api
@@ -89,10 +89,10 @@ spec:
             mkdir -p /usr/local/share/ca-certificates
             
             # Install custom S3 CA if available
-            S3_CERT_FILE="{{ (.Values.airgapped.s3CrtFileLocation | default "s3-custom-ca.crt") | base }}"
+            S3_CERT_FILE="{{ (.Values.airgapped.s3SecretKey | default "s3-custom-ca.crt") | base }}"
             if [ -f "/s3-custom-ca/$S3_CERT_FILE" ]; then
               echo "Installing S3 custom CA certificate..."
-              cp "/s3-custom-ca/$S3_CERT_FILE" /usr/local/share/ca-certificates/s3-custom-ca.crt
+              cp "/s3-custom-ca/$S3_CERT_FILE" "/usr/local/share/ca-certificates/$S3_CERT_FILE"
               # Update CA certificates
               update-ca-certificates
               echo "CA certificates installed successfully"

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -39,6 +39,12 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+      volumes:
+        - name: s3-custom-ca
+          secret:
+            secretName: {{ .Values.airgapped.s3SecretName }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-api
         imagePullPolicy: {{ .Values.services.api.pullPolicy | default "Always" }}
@@ -52,6 +58,12 @@ spec:
           limits:
             memory: {{ .Values.services.api.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.api.cpuLimit | default "500m" | quote}}
+        {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
+        volumeMounts:
+          - name: s3-custom-ca
+            mountPath: /s3-custom-ca
+            readOnly: true
+        {{- end }}
         command:
           - ./bin/docker-entrypoint-api-ee.sh
         envFrom:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -17,7 +17,6 @@ airgapped:
   # variable. Should be the full path to the CA bundle file, e.g.
   # 
   s3SecretName: ""
-  # (default: "s3-custom-ca.crt").
   s3SecretKey: ""
 
 ingress:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -16,9 +16,9 @@ airgapped:
   # mount the CA bundle into the API pod by passing it in as an environment
   # variable. Should be the full path to the CA bundle file, e.g.
   # 
-  s3SecretName: "s3-custom-ca"
+  s3SecretName: ""
   # (default: "s3-custom-ca.crt").
-  s3SecretKey: "s3-custom-ca.crt"
+  s3SecretKey: ""
 
 ingress:
   enabled: true

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -12,6 +12,14 @@ license:
 
 airgapped:
   enabled: false
+  # The boto module used by API does not use the CA bundles in the container, so we need to
+  # mount the CA bundle into the API pod by passing it in as an environment
+  # variable. Should be the full path to the CA bundle file, e.g.
+  # "/s3-custom-ca/s3-custom-ca.crt"
+  s3CrtFileLocation: ""
+  # The file referenced by default in this secret is "s3-custom-ca.crt"
+  # and can be overridden by the s3CrtFileLocation value.
+  s3SecretName: ""
 
 ingress:
   enabled: true

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -15,11 +15,10 @@ airgapped:
   # The boto module used by API does not use the CA bundles in the container, so we need to
   # mount the CA bundle into the API pod by passing it in as an environment
   # variable. Should be the full path to the CA bundle file, e.g.
-  # "/s3-custom-ca/s3-custom-ca.crt"
-  s3CrtFileLocation: "/s3-custom-ca/s3-custom-ca.crt"
-  # The Secret must contain a data key whose name matches the filename in s3CrtFileLocation
+  # 
+  s3SecretName: "s3-custom-ca"
   # (default: "s3-custom-ca.crt").
-  s3SecretName: ""
+  s3SecretKey: "s3-custom-ca.crt"
 
 ingress:
   enabled: true
@@ -76,7 +75,6 @@ services:
     root_user: admin
     root_password: password
     assign_cluster_ip: false
-    use_storage_proxy: false
     env:
       minio_endpoint_ssl: false
 
@@ -252,6 +250,8 @@ env:
   aws_secret_access_key: ''
   aws_region: ''
   aws_s3_endpoint_url: ''
+
+  use_storage_proxy: false
 
   secret_key: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
   api_key_rate_limit: "60/minute"

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -16,9 +16,9 @@ airgapped:
   # mount the CA bundle into the API pod by passing it in as an environment
   # variable. Should be the full path to the CA bundle file, e.g.
   # "/s3-custom-ca/s3-custom-ca.crt"
-  s3CrtFileLocation: ""
-  # The file referenced by default in this secret is "s3-custom-ca.crt"
-  # and can be overridden by the s3CrtFileLocation value.
+  s3CrtFileLocation: "/s3-custom-ca/s3-custom-ca.crt"
+  # The Secret must contain a data key whose name matches the filename in s3CrtFileLocation
+  # (default: "s3-custom-ca.crt").
   s3SecretName: ""
 
 ingress:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -76,6 +76,7 @@ services:
     root_user: admin
     root_password: password
     assign_cluster_ip: false
+    use_storage_proxy: false
     env:
       minio_endpoint_ssl: false
 


### PR DESCRIPTION
- Updated Chart.yaml to version 1.3.4-rc3.
- Added configuration options for CA bundle in values.yaml.
- Modified app-env.yaml to conditionally set AWS_CA_BUNDLE based on airgapped settings.
- Updated api.deployment.yaml to include volume and volumeMounts for the CA bundle when airgapped is enabled.

### Description
Used for overriding Boto's native s3 CA handling. Allows the user to add their own .crt file.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [x] Documentation update

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for custom S3 CA in air-gapped deployments with automatic CA bundle installation in the API pod when enabled; optional secret name/key and a storage-proxy toggle.

- Documentation
  - Updated install/preflight docs, customization reference, and added an Air-gapped Settings section with examples and env var snippets.

- Chores
  - Bumped chart and app versions (chart v1.4.2, app v1.14.1) and default plane image tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->