### PR TITLE
Plane-EE: Bump Plane-EE App Version to `v1.17.0`

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.6.3
-appVersion: "1.16.0"
+version: 1.6.4
+appVersion: "1.17.0"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -11,7 +11,7 @@
    Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
    ```bash
-   PLANE_VERSION=v1.16.0 # or the last released version
+   PLANE_VERSION=v1.17.0 # or the last released version
    DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
    ```
 
@@ -67,7 +67,7 @@
 
      Make sure you set the minimum required values as below.
 
-     - `planeVersion: v1.16.0 <or the last released version>`
+     - `planeVersion: v1.17.0 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
      - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
@@ -93,7 +93,7 @@
 
 | Setting               |      Default      | Required | Description                                                                                                                                                                          |
 | --------------------- | :---------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| planeVersion          |      v1.16.0      |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
+| planeVersion          |      v1.17.0      |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
 | license.licenseDomain | plane.example.com |   Yes    | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Air-gapped Settings

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -20,7 +20,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v1.16.0
+  default: v1.17.0
   required: true
   group: "Docker Registry"
   subquestions:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v1.16.0
+planeVersion: v1.17.0
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION
Bump Plane-EE App Version to `v1.17.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Plane enterprise to version 1.17.0 and Helm chart to version 1.6.4.
  * Updated deployment configurations and defaults to align with the latest application version.

* **Documentation**
  * Updated relevant documentation to reflect Plane version 1.17.0 availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->