### PR TITLE
Plane-EE: Add standard Helm labels

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 1.6.5
+version: 1.6.6
 appVersion: "1.17.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Create chart name and version as used by the chart label.
 Create a default fully qualified app name.
 */}}
 {{- define "plane.name" -}}
-{{- default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -7,7 +7,7 @@
 {{- end -}}
 
 {{- define "plane.podScheduling" -}}
-  {{- with .nodeSelector }} 
+  {{- with .nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
   {{- end }}
   {{- with .tolerations }}
@@ -20,9 +20,52 @@
 
 {{- define "plane.labelsAndAnnotations" -}}
   {{- with .labels }}
-  labels: {{ toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "plane.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "plane.name" -}}
+{{- default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "plane.labels" -}}
+helm.sh/chart: {{ include "plane.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "plane.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ include "plane.name" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels for components
+*/}}
+{{- define "plane.component.labels" -}}
+app.kubernetes.io/name: {{ include "plane.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+app.kubernetes.io/component: {{ .componentName }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: {{ include "plane.name" .context }}
+{{- if .context.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .context.Chart.AppVersion | quote }}
+{{- end }}
+helm.sh/chart: {{ include "plane.chart" .context }}
 {{- end }}

--- a/charts/plane-enterprise/templates/certs/cert-issuers.yaml
+++ b/charts/plane-enterprise/templates/certs/cert-issuers.yaml
@@ -5,16 +5,20 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-issuer-api-token-secret
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   api-token: {{ .Values.ssl.token | default "default-api-token" | quote }}
-  
+
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-cert-issuer
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 spec:
   acme:
     email: {{ .Values.ssl.email }}
@@ -42,5 +46,5 @@ spec:
           ingressClassName: {{ .Values.ingress.ingressClass }}
     {{- end }}
 
---- 
+---
 {{- end}}

--- a/charts/plane-enterprise/templates/certs/certs.yaml
+++ b/charts/plane-enterprise/templates/certs/certs.yaml
@@ -5,6 +5,8 @@ kind: Certificate
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ssl-cert
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 spec:
   dnsNames:
   - {{ .Values.license.licenseDomain | quote }}

--- a/charts/plane-enterprise/templates/certs/email-certs.yaml
+++ b/charts/plane-enterprise/templates/certs/email-certs.yaml
@@ -4,12 +4,14 @@ kind: Certificate
 metadata:
   name: {{ .Release.Name }}-mail-tls-cert
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 spec:
   dnsNames:
   - {{ .Values.env.email_service_envs.smtp_domain | quote }}
-  
+
   issuerRef:
     name: {{ .Release.Name }}-cert-issuer
   secretName: {{ .Release.Name }}-mail-tls-secret
---- 
+---
 {{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-secrets
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 stringData:
   SECRET_KEY: {{ .Values.env.secret_key | default "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5" | quote }}
   AES_SECRET_KEY: {{ .Values.env.silo_envs.aes_secret_key | default "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr" | quote }}
@@ -44,6 +46,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-vars
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 data:
   PRIME_HOST: {{ .Values.license.licenseServer | quote }}
   MACHINE_SIGNATURE: {{ include "hashString" . | quote }}
@@ -78,4 +82,4 @@ data:
   CORS_ALLOWED_ORIGINS: "http://{{ .Values.license.licenseDomain }},https://{{ .Values.license.licenseDomain }},{{ .Values.env.cors_allowed_origins }}"
   {{- else}}
   CORS_ALLOWED_ORIGINS: "http://{{ .Values.license.licenseDomain }},https://{{ .Values.license.licenseDomain }}"
-  {{- end }} 
+  {{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/automations-consumer.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/automations-consumer.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-automation-consumer-vars
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "automation-consumer" "context" $) | nindent 4 }}
 data:
   AUTOMATION_EVENT_STREAM_QUEUE_NAME: {{ .Values.env.automation_consumer_envs.event_stream_queue_name | default "plane.event_stream.automations" | quote }}
   AUTOMATION_EVENT_STREAM_PREFETCH: {{ .Values.env.automation_consumer_envs.event_stream_prefetch | default 10 | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/doc-store.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/doc-store.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-doc-store-secrets
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 stringData:
   FILE_SIZE_LIMIT: {{ .Values.env.file_size_limit | default "5242880" | quote }}
   AWS_S3_BUCKET_NAME: {{ .Values.env.docstore_bucket | default "" | quote  }}

--- a/charts/plane-enterprise/templates/config-secrets/docker-registry.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/docker-registry.yaml
@@ -5,6 +5,8 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-docker-registry-credentials
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ include "imagePullSecret" .}}
 type: kubernetes.io/dockerconfigjson

--- a/charts/plane-enterprise/templates/config-secrets/email-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/email-env.yaml
@@ -5,9 +5,11 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-email-vars
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "email-service" "context" $) | nindent 4 }}
 data:
   SMTP_DOMAIN: {{ .Values.env.email_service_envs.smtp_domain | default "" | quote }}
-  EMAIL_SAVE_ENDPOINT: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/intake/email/" 
+  EMAIL_SAVE_ENDPOINT: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/intake/email/"
   WEBHOOK_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/intake/email/"
   domain-blacklist.txt: |
     10minutemail.com
@@ -17,6 +19,6 @@ data:
     casino
     lottery
     jackpot
-   
+
 ---
 {{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/live-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/live-env.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-secrets
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "live" "context" $) | nindent 4 }}
 stringData:
   LIVE_SERVER_SECRET_KEY: {{ .Values.env.live_server_secret_key | default "htbqvBJAgpm9bzvf3r4urJer0ENReatceh" | quote }}
   {{- if .Values.services.redis.local_setup }}
@@ -21,6 +23,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-vars
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "live" "context" $) | nindent 4 }}
 data:
   API_BASE_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/"
   LIVE_SENTRY_DSN: {{ .Values.env.live_sentry_dsn | default "" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/monitor.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/monitor.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-monitor-vars
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "monitor" "context" $) | nindent 4 }}
 data:
   PRIME_HOST: {{ .Values.license.licenseServer | quote }}
   MACHINE_SIGNATURE: {{ include "hashString" . | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/outbox-poller.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/outbox-poller.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-outbox-poller-vars
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "outbox-poller" "context" $) | nindent 4 }}
 data:
   OUTBOX_POLLER_MEMORY_LIMIT_MB: {{ .Values.env.outbox_poller_envs.memory_limit_mb | default 400 | quote }}
   OUTBOX_POLLER_INTERVAL_MIN: {{ .Values.env.outbox_poller_envs.interval_min | default 0.25 | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/pgdb.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/pgdb.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-secrets
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "pgdb" "context" $) | nindent 4 }}
 stringData:
   POSTGRES_USER: {{ .Values.env.pgdb_username | default "plane" | quote }}
   POSTGRES_PASSWORD: {{ .Values.env.pgdb_password | default "plane" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/rabbitmqdb.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/rabbitmqdb.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq-secrets
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "rabbitmq" "context" $) | nindent 4 }}
 stringData:
   RABBITMQ_DEFAULT_USER: {{ .Values.services.rabbitmq.default_user | default "plane" | quote }}
   RABBITMQ_DEFAULT_PASS: {{ .Values.services.rabbitmq.default_password | default "plane" |quote }}

--- a/charts/plane-enterprise/templates/config-secrets/silo.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/silo.yaml
@@ -6,6 +6,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-silo-secrets
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "silo" "context" $) | nindent 4 }}
 stringData:
   {{- if .Values.env.silo_envs.hmac_secret_key }}
   SILO_HMAC_SECRET_KEY: {{ .Values.env.silo_envs.hmac_secret_key | quote }}
@@ -62,6 +64,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-silo-vars
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "silo" "context" $) | nindent 4 }}
 data:
   PORT: "3000"
   BATCH_SIZE: {{ .Values.env.silo_envs.batch_size | default 100 | quote }}
@@ -75,7 +79,7 @@ data:
   CORS_ALLOWED_ORIGINS: "http://{{ .Values.license.licenseDomain }},https://{{ .Values.license.licenseDomain }},{{ .Values.env.silo_envs.cors_allowed_origins }}"
   {{- else}}
   CORS_ALLOWED_ORIGINS: "http://{{ .Values.license.licenseDomain }},https://{{ .Values.license.licenseDomain }}"
-  {{- end }} 
+  {{- end }}
 
   APP_BASE_URL: "https://{{ .Values.license.licenseDomain }}"
   API_BASE_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}:8000/"

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -11,6 +11,8 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClass }}
   rules:

--- a/charts/plane-enterprise/templates/service-account.yaml
+++ b/charts/plane-enterprise/templates/service-account.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-srv-account
+  labels:
+    {{- include "plane.labels" . | nindent 4 }}
 {{- if .Values.dockerRegistry.enabled }}
 imagePullSecrets:
   - name: {{ .Release.Name }}-docker-registry-credentials

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-admin
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
+    {{- include "plane.component.labels" (dict "componentName" "admin" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.admin.assign_cluster_ip }}
@@ -26,7 +27,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-admin-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.admin }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "admin" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.admin }}
 spec:
   replicas: {{ .Values.services.admin.replicas | default 1 }}
   selector:
@@ -37,6 +40,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
+        {{- include "plane.component.labels" (dict "componentName" "admin" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-api
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
+    {{- include "plane.component.labels" (dict "componentName" "api" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.api.assign_cluster_ip }}
@@ -26,7 +27,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.api }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "api" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.api }}
 spec:
   replicas: {{ .Values.services.api.replicas | default 1}}
   selector:
@@ -37,6 +40,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
+        {{- include "plane.component.labels" (dict "componentName" "api" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:
@@ -73,13 +77,13 @@ spec:
           - -c
           - |
             set -e
-            
+
             {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName }}
             echo "Installing custom CA certificates..."
-            
+
             # Ensure ca-certificates directory exists
             mkdir -p /usr/local/share/ca-certificates
-            
+
             # Install custom S3 CA if available
             S3_CERT_FILE="{{ .Values.airgapped.s3SecretKey }}"
             if [ -f "/s3-custom-ca/$S3_CERT_FILE" ]; then
@@ -92,7 +96,7 @@ spec:
               echo "No custom S3 CA certificate found, skipping..."
             fi
             {{- end }}
-            
+
             # Start the API
             exec ./bin/docker-entrypoint-api-ee.sh
         envFrom:

--- a/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-automation-consumer-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.automation_consumer }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "automation-consumer" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.automation_consumer }}
 spec:
   replicas: {{ .Values.services.automation_consumer.replicas | default 1}}
   selector:
@@ -15,6 +17,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-automation-consumer
+        {{- include "plane.component.labels" (dict "componentName" "automation-consumer" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -3,7 +3,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-beat-worker-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.beatworker }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "beat-worker-wl" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.beatworker }}
 spec:
   replicas: {{ .Values.services.beatworker.replicas | default 1 }}
   selector:
@@ -14,6 +16,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
+        {{- include "plane.component.labels" (dict "componentName" "beat-worker-wl" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/email.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/email.deployment.yaml
@@ -5,6 +5,8 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-email-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "email-service" "context" $) | nindent 4 }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local  # Important for email servers
@@ -32,7 +34,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     reloader.stakater.com/auto: "true"
-  {{- include "plane.labelsAndAnnotations" .Values.services.email_service }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "email-service" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.email_service }}
 spec:
   replicas: {{ .Values.services.email_service.replicas | default 1 }}
   selector:
@@ -42,8 +46,9 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       labels:
-       app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-email-app 
-      annotations:  
+       app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-email-app
+       {{- include "plane.component.labels" (dict "componentName" "email-service" "context" $) | nindent 8 }}
+      annotations:
         timestamp: {{ now | quote }}
     spec:
       containers:

--- a/charts/plane-enterprise/templates/workloads/email.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/email.deployment.yaml
@@ -46,8 +46,8 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       labels:
-       app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-email-app
-       {{- include "plane.component.labels" (dict "componentName" "email-service" "context" $) | nindent 8 }}
+        app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-email-app
+        {{- include "plane.component.labels" (dict "componentName" "email-service" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-iframely
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-iframely
+    {{- include "plane.component.labels" (dict "componentName" "iframely" "context" $) | nindent 4 }}
 spec:
   clusterIP: None
   ports:
@@ -23,7 +24,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-iframely-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.iframely }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "iframely" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.iframely }}
 spec:
   replicas: {{ .Values.services.iframely.replicas | default 1 }}
   selector:
@@ -34,6 +37,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-iframely
+        {{- include "plane.component.labels" (dict "componentName" "iframely" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-live
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+    {{- include "plane.component.labels" (dict "componentName" "live" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.live.assign_cluster_ip }}
@@ -26,7 +27,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.live }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "live" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.live }}
 spec:
   replicas: {{ .Values.services.live.replicas | default 1}}
   selector:
@@ -37,6 +40,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+        {{- include "plane.component.labels" (dict "componentName" "live" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/migrator.job.yaml
@@ -4,20 +4,23 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-migrate-{{ now | date "20060102-150405" }}
-  {{- include "plane.labelsAndAnnotations" .Values.services.api }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "api-migrate" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.api }}
 spec:
   backoffLimit: 3
   template:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
+        {{- include "plane.component.labels" (dict "componentName" "api-migrate" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api-migrate
         image: {{ .Values.services.api.image | default "artifacts.plane.so/makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
-        command: 
+        command:
           - ./bin/docker-entrypoint-migrator.sh
         imagePullPolicy: {{ .Values.services.api.pullPolicy | default "Always" }}
         envFrom:

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-minio
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
+    {{- include "plane.component.labels" (dict "componentName" "minio" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.minio.assign_cluster_ip }}
@@ -29,7 +30,9 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.minio }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "minio" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.minio }}
 spec:
   selector:
     matchLabels:
@@ -39,6 +42,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
+        {{- include "plane.component.labels" (dict "componentName" "minio" "context" $) | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.services.minio.image }}
@@ -50,7 +54,7 @@ spec:
         args:
           - server
           - /data
-          - --console-address 
+          - --console-address
           - :9090
         envFrom:
           - secretRef:
@@ -86,12 +90,16 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-bucket-{{ now | date "20060102-150405" }}
-  {{- include "plane.labelsAndAnnotations" .Values.services.minio }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "minio" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.minio }}
 spec:
   backoffLimit: 6
   completionMode: NonIndexed
   template:
     metadata:
+      labels:
+        {{- include "plane.component.labels" (dict "componentName" "minio" "context" $) | nindent 8 }}
       namespace: {{ .Release.Namespace }}
     spec:
       restartPolicy: OnFailure
@@ -109,8 +117,8 @@ spec:
             - '-c'
             - >-
               /usr/bin/mc config host add plane-app-minio
-              http://{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"; 
-              /usr/bin/mc mb plane-app-minio/$AWS_S3_BUCKET_NAME; 
+              http://{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY";
+              /usr/bin/mc mb plane-app-minio/$AWS_S3_BUCKET_NAME;
               /usr/bin/mc anonymous set download plane-app-minio/$AWS_S3_BUCKET_NAME; exit 0;
           envFrom:
             - secretRef:

--- a/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Release.Name }}-monitor
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-monitor
+    {{- include "plane.component.labels" (dict "componentName" "monitor" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.monitor.assign_cluster_ip }}
@@ -24,7 +25,9 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-monitor-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.monitor }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "monitor" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.monitor }}
 spec:
   selector:
     matchLabels:
@@ -34,6 +37,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-monitor
+        {{- include "plane.component.labels" (dict "componentName" "monitor" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:
@@ -86,4 +90,3 @@ spec:
           storage: {{ .Values.services.monitor.volumeSize | default "100Mi" | quote }}
       storageClassName: {{ .Values.env.storageClass | quote }}
       volumeMode: Filesystem
-      

--- a/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-outbox-poller-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.outbox_poller }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "outbox-poller" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.outbox_poller }}
 spec:
   replicas: {{ .Values.services.outbox_poller.replicas | default 1}}
   selector:
@@ -15,6 +17,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-outbox-poller
+        {{- include "plane.component.labels" (dict "componentName" "outbox-poller" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-pgdb
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
+    {{- include "plane.component.labels" (dict "componentName" "pgdb" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.postgres.assign_cluster_ip }}
@@ -25,7 +26,9 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.postgres }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "pgdb" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.postgres }}
 spec:
   selector:
     matchLabels:
@@ -35,6 +38,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
+        {{- include "plane.component.labels" (dict "componentName" "pgdb" "context" $) | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.services.postgres.image }}
@@ -74,5 +78,5 @@ spec:
           storage: {{ .Values.services.postgres.volumeSize | default "5Gi" | quote }}
       storageClassName: {{ .Values.env.storageClass | quote }}
       volumeMode: Filesystem
-      
+
 {{- end }}

--- a/charts/plane-enterprise/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/rabbitmq.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-rabbitmq
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
+    {{- include "plane.component.labels" (dict "componentName" "rabbitmq" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.rabbitmq.assign_cluster_ip }}
@@ -29,7 +30,9 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.rabbitmq }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "rabbitmq" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.rabbitmq }}
 spec:
   selector:
     matchLabels:
@@ -39,6 +42,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
+        {{- include "plane.component.labels" (dict "componentName" "rabbitmq" "context" $) | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.services.rabbitmq.image }}
@@ -83,5 +87,5 @@ spec:
           storage: {{ .Values.services.rabbitmq.volumeSize | default "100Mi" | quote }}
       storageClassName: {{ .Values.env.storageClass }}
       volumeMode: Filesystem
-      
+
 {{- end }}

--- a/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-redis
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
+    {{- include "plane.component.labels" (dict "componentName" "redis" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.redis.assign_cluster_ip }}
@@ -28,16 +29,19 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-redis-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.redis }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "redis" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.redis }}
 spec:
   selector:
     matchLabels:
       app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
-  serviceName:  {{ .Release.Name }}-redis
+  serviceName: {{ .Release.Name }}-redis
   template:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
+        {{- include "plane.component.labels" (dict "componentName" "redis" "context" $) | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.services.redis.image }}
@@ -71,5 +75,5 @@ spec:
           storage: {{ .Values.services.redis.volumeSize | default "1Gi" | quote }}
       storageClassName: {{ .Values.env.storageClass | quote }}
       volumeMode: Filesystem
-      
+
 {{- end }}

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-silo
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
+    {{- include "plane.component.labels" (dict "componentName" "silo" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.silo.assign_cluster_ip }}
@@ -27,7 +28,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-silo-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.silo }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "silo" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.silo }}
 spec:
   replicas: {{ .Values.services.silo.replicas | default 1}}
   selector:
@@ -38,6 +41,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
+        {{- include "plane.component.labels" (dict "componentName" "silo" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:
@@ -49,15 +53,15 @@ spec:
         args:
           - '-c'
           - >-
-            if echo "$AMQP_URL" | grep -q "rabbitmq.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}"; then 
-              echo "Waiting for local RabbitMQ..."; 
+            if echo "$AMQP_URL" | grep -q "rabbitmq.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}"; then
+              echo "Waiting for local RabbitMQ...";
               until nslookup {{ .Release.Name }}-rabbitmq.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }} > /dev/null 2>&1; do
-                echo "RabbitMQ not ready..."; 
-                sleep 5; 
-              done; 
-              echo "RabbitMQ is up!"; 
-            else 
-              echo "Skipping wait, using external RabbitMQ"; 
+                echo "RabbitMQ not ready...";
+                sleep 5;
+              done;
+              echo "RabbitMQ is up!";
+            else
+              echo "Skipping wait, using external RabbitMQ";
             fi;
         envFrom:
           - configMapRef:

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-space
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
+    {{- include "plane.component.labels" (dict "componentName" "space" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.space.assign_cluster_ip }}
@@ -26,7 +27,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-space-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.space }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "space" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.space }}
 spec:
   replicas: {{ .Values.services.space.replicas | default 1 }}
   selector:
@@ -37,6 +40,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
+        {{- include "plane.component.labels" (dict "componentName" "space" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-web
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
+    {{- include "plane.component.labels" (dict "componentName" "web" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.web.assign_cluster_ip }}
@@ -26,7 +27,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-web-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.web }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "web" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.web }}
 spec:
   replicas: {{ .Values.services.web.replicas | default 1 }}
   selector:
@@ -37,6 +40,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
+        {{- include "plane.component.labels" (dict "componentName" "web" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -3,7 +3,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-worker-wl
-  {{- include "plane.labelsAndAnnotations" .Values.services.worker }}
+  labels:
+    {{- include "plane.component.labels" (dict "componentName" "worker" "context" $) | nindent 4 }}
+    {{- include "plane.labelsAndAnnotations" .Values.services.worker }}
 spec:
   replicas: {{ .Values.services.worker.replicas | default 1 }}
   selector:
@@ -14,6 +16,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
+        {{- include "plane.component.labels" (dict "componentName" "worker" "context" $) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:
@@ -50,13 +53,13 @@ spec:
           - -c
           - |
             set -e
-            
+
             {{- if and .Values.airgapped.enabled .Values.airgapped.s3SecretName .Values.airgapped.s3SecretKey }}
             echo "Installing custom CA certificates..."
-            
+
             # Ensure ca-certificates directory exists
             mkdir -p /usr/local/share/ca-certificates
-            
+
             # Install custom S3 CA if available
             S3_CERT_FILE="{{ .Values.airgapped.s3SecretKey }}"
             if [ -f "/s3-custom-ca/$S3_CERT_FILE" ]; then
@@ -69,7 +72,7 @@ spec:
               echo "No custom S3 CA certificate found, skipping..."
             fi
             {{- end }}
-            
+
             # Start the worker
             exec ./bin/docker-entrypoint-worker.sh
         envFrom:


### PR DESCRIPTION
### Description

Fixes #135 by adding [Helm Standard Labels](https://helm.sh/docs/chart_best_practices/labels/#standard-labels). In addition to the recommended labels, the optional ones were also added to differentiate the components and also see which non-plane specific components (like Postgres, Redis, RabbitMQ) are also part of a Helm release.

- Added helper template functions for common labels and common component labels
- Added labels via these helper functions to all resources and the Pods created by the template specs
- The selector labels were not touched, as these are [immutable](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates).

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Test Scenarios 

- Deploy current plane-enterprise `1.6.5` Helm Chart
- Update the Helm release with this change
- Verify that components are still working as expected

### References

#135 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 1.6.6
* **New Features**
  * Added standardized chart- and component-level labels across Kubernetes resources for clearer ownership and filtering
* **Configuration**
  * Added new configuration keys: APP_DOMAIN, APP_VERSION, DEPLOY_PLATFORM, API_URL, API_HOSTNAME, LIVE_SERVER_SECRET_KEY
* **Style**
  * Unified manifest formatting, document boundaries, and template indentation for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->