### PR TITLE
[wip]: add labels for prometheus monitoring

### DIFF
--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -26,3 +26,12 @@
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
+{{- define "plane.prometheusAnnotations" -}}
+{{- if and .root.Values.monitoring .root.Values.monitoring.enabled -}}
+prometheus.io/scrape: {{ .root.Values.monitoring.prometheus.scrape | quote }}
+prometheus.io/port: {{ .port | quote }}
+prometheus.io/path: {{ .root.Values.monitoring.prometheus.path | quote }}
+prometheus.io/scheme: {{ .root.Values.monitoring.prometheus.scheme | quote }}
+{{- end }}
+{{- end }}

--- a/charts/plane-enterprise/templates/ingress-traefik.yaml
+++ b/charts/plane-enterprise/templates/ingress-traefik.yaml
@@ -1,0 +1,84 @@
+{{- if and .Values.ingress.enabled (eq .Values.ingress.ingressClass "traefik-external") .Values.license.licenseDomain }}
+
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ .Release.Name }}-ingress
+  namespace: {{ .Release.Namespace }}
+spec:
+  entryPoints:
+    - websecure
+
+  routes:
+
+  # IMPORTANT: specific paths FIRST
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/spaces/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-space
+        port: 3000
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/god-mode/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-admin
+        port: 3000
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/api/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-api
+        port: 8000
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/auth/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-api
+        port: 8000
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/graphql/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-api
+        port: 8000
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/marketplace/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-api
+        port: 8000
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/live/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-live
+        port: 3000
+
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/silo/`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-silo
+        port: 3000
+
+  {{- if and .Values.services.minio.local_setup .Values.env.docstore_bucket }}
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/{{ .Values.env.docstore_bucket }}`)
+    kind: Rule
+    services:
+      - name: {{ .Release.Name }}-minio
+        port: 9000
+  {{- end }}
+
+  # LAST: catch all
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/`)
+    kind: Rule
+    middlewares:
+      - name: {{ .Release.Name }}-body-limit
+    services:
+      - name: {{ .Release.Name }}-web
+        port: 3000
+
+  tls:
+    secretName: {{ default (printf "%s-ssl-cert" .Release.Name) .Values.ssl.tls_secret_name }}
+
+{{- end }}

--- a/charts/plane-enterprise/templates/ingress-traefik.yaml
+++ b/charts/plane-enterprise/templates/ingress-traefik.yaml
@@ -5,6 +5,11 @@ kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: plane-ingress
+    app.kubernetes.io/component: ingress
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   entryPoints:
     - websecure

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.license.licenseDomain }}
+{{- if and .Values.ingress.enabled (eq .Values.ingress.ingressClass "nginx") .Values.license.licenseDomain }}
 
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/plane-enterprise/templates/traefik-middleware.yaml
+++ b/charts/plane-enterprise/templates/traefik-middleware.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.ingress.enabled (eq .Values.ingress.ingressClass "traefik-external") }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .Release.Name }}-body-limit
+  namespace: {{ .Release.Namespace }}
+spec:
+  buffering:
+    maxRequestBodyBytes: 5242880
+
+{{- end }}

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -4,8 +4,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-admin
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" "3000" "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
+    app.kubernetes.io/name: plane-admin
+    app.kubernetes.io/component: admin
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.admin.assign_cluster_ip }}
@@ -37,6 +45,11 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
+        app.kubernetes.io/name: plane-admin
+        app.kubernetes.io/component: admin
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -4,8 +4,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" "8000" "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
+    app.kubernetes.io/name: plane-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.api.assign_cluster_ip }}
@@ -37,6 +45,11 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
+        app.kubernetes.io/name: plane-api
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -4,8 +4,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" "3000" "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+    app.kubernetes.io/name: plane-live
+    app.kubernetes.io/component: live
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.live.assign_cluster_ip }}
@@ -37,6 +45,11 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+        app.kubernetes.io/name: plane-live
+        app.kubernetes.io/component: live
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -5,8 +5,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" "9000" "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
+    app.kubernetes.io/name: plane-minio
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.minio.assign_cluster_ip }}
@@ -39,6 +47,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
+        app.kubernetes.io/name: plane-minio
+        app.kubernetes.io/component: minio
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
     spec:
       containers:
       - image: {{ .Values.services.minio.image }}

--- a/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
@@ -5,8 +5,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" (.Values.services.postgres.servicePort | toString) "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
+    app.kubernetes.io/name: plane-postgres
+    app.kubernetes.io/component: postgres
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.postgres.assign_cluster_ip }}
@@ -35,6 +43,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
+        app.kubernetes.io/name: plane-postgres
+        app.kubernetes.io/component: postgres
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
     spec:
       containers:
       - image: {{ .Values.services.postgres.image }}

--- a/charts/plane-enterprise/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/rabbitmq.stateful.yaml
@@ -5,8 +5,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" (.Values.services.rabbitmq.managementPort | toString) "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
+    app.kubernetes.io/name: plane-rabbitmq
+    app.kubernetes.io/component: rabbitmq
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.rabbitmq.assign_cluster_ip }}
@@ -39,6 +47,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
+        app.kubernetes.io/name: plane-rabbitmq
+        app.kubernetes.io/component: rabbitmq
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
     spec:
       containers:
       - image: {{ .Values.services.rabbitmq.image }}

--- a/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
@@ -5,8 +5,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-redis
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" (.Values.services.redis.servicePort | toString) "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
+    app.kubernetes.io/name: plane-redis
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.redis.assign_cluster_ip }}
@@ -38,6 +46,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
+        app.kubernetes.io/name: plane-redis
+        app.kubernetes.io/component: redis
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
     spec:
       containers:
       - image: {{ .Values.services.redis.image }}

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -5,8 +5,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-silo
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" "3000" "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
+    app.kubernetes.io/name: plane-silo
+    app.kubernetes.io/component: silo
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.silo.assign_cluster_ip }}
@@ -38,6 +46,11 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
+        app.kubernetes.io/name: plane-silo
+        app.kubernetes.io/component: silo
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -4,8 +4,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-space
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" "3000" "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
+    app.kubernetes.io/name: plane-space
+    app.kubernetes.io/component: space
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.space.assign_cluster_ip }}
@@ -37,6 +45,11 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
+        app.kubernetes.io/name: plane-space
+        app.kubernetes.io/component: space
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -4,8 +4,16 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-web
+  {{- if and .Values.monitoring .Values.monitoring.enabled }}
+  annotations:
+    {{- include "plane.prometheusAnnotations" (dict "port" "3000" "root" .) | nindent 4 }}
+  {{- end }}
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
+    app.kubernetes.io/name: plane-web
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: plane-enterprise
+    app.kubernetes.io/managed-by: helm
 spec:
   type: ClusterIP
   {{- if not .Values.services.web.assign_cluster_ip }}
@@ -37,6 +45,11 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
+        app.kubernetes.io/name: plane-web
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: plane-enterprise
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.planeVersion }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -25,8 +25,9 @@ ingress:
   enabled: true
   minioHost: ''
   rabbitmqHost: ''
-  ingressClass: 'nginx'
+  # ingressClass: 'nginx'
   ingress_annotations: { "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }
+  ingressClass: 'traefik-external'
 
 ssl:
   tls_secret_name: '' # If you have a custom TLS secret name

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -39,6 +39,13 @@ ssl:
   email: plane@example.com
   generateCerts: false
 
+monitoring:
+  enabled: false
+  prometheus:
+    scrape: true
+    path: "/metrics"
+    scheme: "http"
+
 services:
   redis:
     local_setup: true


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus monitoring support with optional scraping annotations across all services
  * Added Traefik ingress controller as an alternative routing option alongside existing NGINX support
  * Enhanced service discovery and management through standardized Kubernetes resource labels

* **Chores**
  * Improved infrastructure metadata and labeling for better observability and resource tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->