### PR TITLE
Plane-EE: Add Follower Postgres URI configuration option in pi-api-env

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.2.3
+version: 2.2.4
 appVersion: "2.4.2"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -795,6 +795,10 @@ questions:
     label: "Assign Cluster IP"
     type: boolean
     default: false
+  - variable: env.pi_envs.follower_postgres_uri
+    label: "Follower Postgres URI"
+    type: string
+    default: ""
   - variable: env.pi_envs.plane_oauth.state_expiry_seconds
     label: "Plane OAuth State Expiry Seconds"
     type: int

--- a/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
@@ -15,11 +15,13 @@ stringData:
   PLANE_PI_DATABASE_URL: ""
   {{- end }}
 
-  {{- if .Values.services.postgres.local_setup }}
+  {{- if .Values.env.pi_envs.follower_postgres_uri }}
+  FOLLOWER_POSTGRES_URI: {{ .Values.env.pi_envs.follower_postgres_uri | quote }}
+  {{- else if .Values.services.postgres.local_setup }}
   FOLLOWER_POSTGRES_URI: "postgresql://{{ .Values.env.pgdb_username }}:{{ .Values.env.pgdb_password }}@{{ .Release.Name }}-pgdb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.env.pgdb_name }}"
   {{- else if .Values.env.pgdb_remote_url }}
   FOLLOWER_POSTGRES_URI: {{ .Values.env.pgdb_remote_url | quote }}
-  {{- else }}
+  {{- else }}  
   FOLLOWER_POSTGRES_URI: ""
   {{- end }}
 

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -513,6 +513,7 @@ env:
     plane_oauth:
       state_expiry_seconds: 82800
     plane_api_host: ''
+    follower_postgres_uri: ''
     cors_allowed_origins: ''
     internal_secret: 'tyfvfqvBJAgpm9bzvf3r4urJer0Ehfdubk'
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
* Added support for configuring a Follower Postgres URI in Plane Enterprise Helm chart with flexible precedence logic.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Improvement (change that would cause existing functionality to not work as expected)
