### PR TITLE
release: Plane-EE `v2.5.1`

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.2.5
-appVersion: "2.5.0"
+version: 2.2.6
+appVersion: "2.5.1"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -11,7 +11,7 @@
    Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
    ```bash
-   PLANE_VERSION=v2.5.0 # or the last released version
+   PLANE_VERSION=v2.5.1 # or the last released version
    DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
    ```
 
@@ -67,7 +67,7 @@
 
      Make sure you set the minimum required values as below.
 
-     - `planeVersion: v2.5.0 <or the last released version>`
+     - `planeVersion: v2.5.1 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
      - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
@@ -93,7 +93,7 @@
 
 | Setting               |      Default      | Required | Description                                                                                                                                                                          |
 | --------------------- | :---------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| planeVersion          |      v2.5.0       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
+| planeVersion          |      v2.5.1       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
 | license.licenseDomain | plane.example.com |   Yes    | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Air-gapped Settings
@@ -242,6 +242,7 @@ airgapped:
 | env.aws_s3_endpoint_url               |                    |          | External `S3` (or compatible) storage service providers shares a `endpoint_url` for the integration purpose for the application to connect and do the necessary upload/download operations. To be provided when `services.minio.local_setup=false`                                                                                                    |
 | env.use_storage_proxy                 |       false        |          | When set to `true`, all S3 (or compatible) file GET requests from the browser are proxied through Plane's API service instead of accessing the S3 endpoint directly. Enable this if your storage endpoint is not accessible publicly or you want to control/download access through the API. Default is `false`.                                      |
 | env.allow_all_attachment_types       |       false        |          | When set to `true`, allows all file types as attachments. When `false`, only permitted types are allowed. Default is `false`.                                                                                                                                                        |
+| env.enable_drf_spectacular            |       false        |          | When set to `true`, enables drf-spectacular OpenAPI schema generation for the API (`ENABLE_DRF_SPECTACULAR`). Default is `false`.                                                                                                                                                       |
 
 ### Web Deployment
 

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -27,7 +27,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v2.5.0
+  default: v2.5.1
   required: true
   group: "Docker Registry"
   subquestions:
@@ -483,6 +483,10 @@ questions:
     default: "60/minute"
   - variable: env.allow_all_attachment_types
     label: "Allow All Attachment Types"
+    type: boolean
+    default: false
+  - variable: env.enable_drf_spectacular
+    label: "Enable DRF Spectacular (OpenAPI)"
     type: boolean
     default: false
   - variable: env.web_url

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -56,6 +56,7 @@ data:
   MINIO_ENDPOINT_SSL: {{ .Values.services.minio.env.minio_endpoint_ssl | default false | ternary "1" "0" | quote }}
   USE_STORAGE_PROXY: {{ .Values.env.use_storage_proxy | default false | ternary "1" "0" | quote }}
   ALLOW_ALL_ATTACHMENT_TYPES: {{ .Values.env.allow_all_attachment_types | default false | ternary "1" "0" | quote }}
+  ENABLE_DRF_SPECTACULAR: {{ .Values.env.enable_drf_spectacular | default false | ternary "1" "0" | quote }}
   INTAKE_EMAIL_DOMAIN: {{ .Values.env.email_service_envs.smtp_domain | default "" | quote }}
 
   SENTRY_DSN: {{ .Values.env.sentry_dsn | default "" | quote}}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v2.5.0
+planeVersion: v2.5.1
 
 dockerRegistry:
   enabled: false
@@ -449,6 +449,7 @@ env:
 
   use_storage_proxy: false
   allow_all_attachment_types: false
+  enable_drf_spectacular: false
 
   #OPENSEARCH ENVS
   opensearch_remote_url: ''


### PR DESCRIPTION


### Description
<!-- Provide a detailed description of the changes in this PR -->
* Update default Plane version to v2.5.1 in questions.yml, README.md, and values.yaml
* Add env `ENABLE_DRF_SPECTACULAR` in plane-ee app-env.yaml


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] App Version Update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option to enable OpenAPI schema generation for the API (disabled by default).

* **Chores**
  * Updated Helm chart version to 2.2.6 and application version to 2.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->