### PR TITLE
release: Plane-EE`v2.5.2`

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.2.6
-appVersion: "2.5.1"
+version: 2.2.7
+appVersion: "2.5.2"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -11,7 +11,7 @@
    Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
    ```bash
-   PLANE_VERSION=v2.5.1 # or the last released version
+   PLANE_VERSION=v2.5.2 # or the last released version
    DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
    ```
 
@@ -67,7 +67,7 @@
 
      Make sure you set the minimum required values as below.
 
-     - `planeVersion: v2.5.1 <or the last released version>`
+     - `planeVersion: v2.5.2 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
      - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
@@ -93,7 +93,7 @@
 
 | Setting               |      Default      | Required | Description                                                                                                                                                                          |
 | --------------------- | :---------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| planeVersion          |      v2.5.1       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
+| planeVersion          |      v2.5.2       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
 | license.licenseDomain | plane.example.com |   Yes    | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Air-gapped Settings
@@ -215,6 +215,7 @@ airgapped:
 | env.opensearch_remote_username           |                                   |          | Username for remote OpenSearch service. Required when `services.opensearch.local_setup=false` and `env.opensearch_remote_url` is set. Note: This is not a secret and should be configured in values.yaml, not in external secrets.                                                                                                                                                                                                      |
 | env.opensearch_remote_password           |                                   |          | Password for remote OpenSearch service. Required when `services.opensearch.local_setup=false` and `env.opensearch_remote_url` is set. This can be configured in values.yaml or provided via external secrets (`opensearch_existingSecret` with `OPENSEARCH_PASSWORD`). **Password Complexity Requirements:** Must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character (e.g., `!@#$%^&*`). |
 | env.opensearch_index_prefix              |              plane_               |          | Prefix to be used for OpenSearch indices. This helps organize indices in a multi-tenant or multi-environment setup.                                                                                                                                                                                                                        |
+| env.opensearch_embedding_dimension       |               1536                |          | Embedding vector dimension used for OpenSearch semantic/vector indexing.                                                                                                                                                                                                                               |
 
 ### Doc Store (Minio/S3) Setup
 
@@ -625,6 +626,7 @@ To configure the external secrets for your application, you need to define speci
 |                          | `OPENSEARCH_PASSWORD`  | Required if OpenSearch is enabled                                | Password for OpenSearch                      | **local setup**: `Secure@Pass#123!%^&*` <br> <br> **remote setup**: `your_remote_password`                                                                                                            |
 |                          | `OPENSEARCH_INITIAL_ADMIN_PASSWORD` | Required if `opensearch.local_setup=true` | Initial admin password for local OpenSearch  | `Secure@Pass#123!%^&*`                                                                                                                                                                                |
 |                          | `OPENSEARCH_INDEX_PREFIX` | Optional                                                       | Prefix for OpenSearch indices                | `plane_`                                                                                                                                                                                              |
+|                          | `OPENSEARCH_EMBEDDING_DIMENSION` | Optional                                                | Embedding vector dimension for OpenSearch    | `1536`                                                                                                                                                                                                |
 | doc_store_existingSecret | `USE_MINIO`             | Yes                                                             | Flag to enable MinIO as the storage backend | `1`                                                                                                                                                                                                  |
 |                          | `MINIO_ROOT_USER`       | Yes                                                             | MinIO root user                             | `admin`                                                                                                                                                                                              |
 |                          | `MINIO_ROOT_PASSWORD`   | Yes                                                             | MinIO root password                         | `password`                                                                                                                                                                                           |

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -27,7 +27,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v2.5.1
+  default: v2.5.2
   required: true
   group: "Docker Registry"
   subquestions:
@@ -1199,6 +1199,10 @@ questions:
     label: "Index Prefix"
     type: string
     default: ""
+  - variable: env.opensearch_embedding_dimension
+    label: "Embedding Dimension"
+    type: int
+    default: 1536
 
 - variable: services.rabbitmq.local_setup
   label: "Install RabbitMQ"

--- a/charts/plane-enterprise/templates/config-secrets/opensearchdb.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/opensearchdb.yaml
@@ -13,18 +13,21 @@ stringData:
   OPENSEARCH_PASSWORD: {{ .Values.services.opensearch.password | default "Secure@Pass#123!%^&*" | quote }}
   OPENSEARCH_INITIAL_ADMIN_PASSWORD: {{ .Values.services.opensearch.password | default "Secure@Pass#123!%^&*" | quote }}
   OPENSEARCH_INDEX_PREFIX: {{ .Values.env.opensearch_index_prefix | default "" | quote }}
+  OPENSEARCH_EMBEDDING_DIMENSION: {{ .Values.env.opensearch_embedding_dimension | default 1536 | quote }}
   {{- else if .Values.env.opensearch_remote_url }}
   OPENSEARCH_ENABLED: "1"
   OPENSEARCH_URL: {{ .Values.env.opensearch_remote_url | quote }}
   OPENSEARCH_USERNAME: {{ .Values.env.opensearch_remote_username | default "" | quote }}
   OPENSEARCH_PASSWORD: {{ .Values.env.opensearch_remote_password | default "" | quote }}
   OPENSEARCH_INDEX_PREFIX: {{ .Values.env.opensearch_index_prefix | default "" | quote }}
+  OPENSEARCH_EMBEDDING_DIMENSION: {{ .Values.env.opensearch_embedding_dimension | default 1536 | quote }}
   {{- else }}
   OPENSEARCH_ENABLED: "0"
   OPENSEARCH_URL: ""
   OPENSEARCH_USERNAME: ""
   OPENSEARCH_PASSWORD: ""
   OPENSEARCH_INDEX_PREFIX: ""
+  OPENSEARCH_EMBEDDING_DIMENSION: {{ .Values.env.opensearch_embedding_dimension | default 1536 | quote }}
   {{- end }}
 {{- end }}
 ---

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v2.5.1
+planeVersion: v2.5.2
 
 dockerRegistry:
   enabled: false
@@ -456,6 +456,7 @@ env:
   opensearch_remote_username: ''
   opensearch_remote_password: ''
   opensearch_index_prefix: ''
+  opensearch_embedding_dimension: 1536
 
   #API KEYS
   secret_key: "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

- This pull request updates the Plane Enterprise Helm chart to version 2.2.7 (Plane EE app version 2.5.2)

- Add env `OPENSEARCH_EMBEDDING_DIMENSION` in opensearchdb.yaml file


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] AppVersion Update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.5.2

* **New Features**
  * Added configurable OpenSearch embedding dimension setting (default: 1536) for enhanced search customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->