### PR TITLE
feat(plane-ce): expose podSecurityContext and containerSecurityContext via values

### DIFF
--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -39,9 +39,17 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- with .Values.admin.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-admin
         imagePullPolicy: {{ .Values.admin.pullPolicy | default "Always" }}
+        {{- with .Values.admin.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ .Values.admin.image | default "artifacts.plane.so/makeplane/plane-frontend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -39,9 +39,17 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- with .Values.api.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-api
         imagePullPolicy: {{ .Values.api.pullPolicy | default "Always" }}
+        {{- with .Values.api.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ .Values.api.image | default "artifacts.plane.so/makeplane/plane-backend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -17,9 +17,17 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- with .Values.beatworker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-beat-worker
         imagePullPolicy: {{ .Values.beatworker.pullPolicy | default "Always" }}
+        {{- with .Values.beatworker.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ .Values.beatworker.image | default "artifacts.plane.so/makeplane/plane-backend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -39,9 +39,17 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- with .Values.live.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-live
         imagePullPolicy: {{ .Values.live.pullPolicy | default "Always" }}
+        {{- with .Values.live.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ .Values.live.image | default "artifacts.plane.so/makeplane/plane-live" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -39,9 +39,17 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- with .Values.space.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-space
         imagePullPolicy: {{ .Values.space.pullPolicy | default "Always" }}
+        {{- with .Values.space.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ .Values.space.image | default "artifacts.plane.so/makeplane/plane-space" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -39,9 +39,17 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- with .Values.web.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-web
         imagePullPolicy: {{ .Values.web.pullPolicy | default "Always" }}
+        {{- with .Values.web.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ .Values.web.image | default "artifacts.plane.so/makeplane/plane-frontend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -17,9 +17,17 @@ spec:
       annotations:
         timestamp: {{ now | quote }}
     spec:
+      {{- with .Values.worker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-worker
         imagePullPolicy: {{ .Values.worker.pullPolicy | default "Always" }}
+        {{- with .Values.worker.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ .Values.worker.image | default "artifacts.plane.so/makeplane/plane-backend" }}:{{ .Values.planeVersion }}
         stdin: true
         tty: true

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -109,6 +109,12 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # podSecurityContext sets pod-level securityContext (e.g. fsGroup,
+  # runAsUser, seccompProfile). Empty = no pod-level securityContext rendered.
+  podSecurityContext: {}
+  # containerSecurityContext sets container-level securityContext (e.g.
+  # runAsNonRoot, capabilities.drop, allowPrivilegeEscalation). Empty = none rendered.
+  containerSecurityContext: {}
 
 space:
   replicas: 1
@@ -124,6 +130,12 @@ space:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # podSecurityContext sets pod-level securityContext (e.g. fsGroup,
+  # runAsUser, seccompProfile). Empty = no pod-level securityContext rendered.
+  podSecurityContext: {}
+  # containerSecurityContext sets container-level securityContext (e.g.
+  # runAsNonRoot, capabilities.drop, allowPrivilegeEscalation). Empty = none rendered.
+  containerSecurityContext: {}
 
 admin:
   replicas: 1
@@ -139,6 +151,12 @@ admin:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # podSecurityContext sets pod-level securityContext (e.g. fsGroup,
+  # runAsUser, seccompProfile). Empty = no pod-level securityContext rendered.
+  podSecurityContext: {}
+  # containerSecurityContext sets container-level securityContext (e.g.
+  # runAsNonRoot, capabilities.drop, allowPrivilegeEscalation). Empty = none rendered.
+  containerSecurityContext: {}
 
 live:
   replicas: 1
@@ -154,6 +172,12 @@ live:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # podSecurityContext sets pod-level securityContext (e.g. fsGroup,
+  # runAsUser, seccompProfile). Empty = no pod-level securityContext rendered.
+  podSecurityContext: {}
+  # containerSecurityContext sets container-level securityContext (e.g.
+  # runAsNonRoot, capabilities.drop, allowPrivilegeEscalation). Empty = none rendered.
+  containerSecurityContext: {}
 
 api:
   replicas: 1
@@ -169,6 +193,12 @@ api:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # podSecurityContext sets pod-level securityContext (e.g. fsGroup,
+  # runAsUser, seccompProfile). Empty = no pod-level securityContext rendered.
+  podSecurityContext: {}
+  # containerSecurityContext sets container-level securityContext (e.g.
+  # runAsNonRoot, capabilities.drop, allowPrivilegeEscalation). Empty = none rendered.
+  containerSecurityContext: {}
 
 worker:
   replicas: 1
@@ -183,6 +213,12 @@ worker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # podSecurityContext sets pod-level securityContext (e.g. fsGroup,
+  # runAsUser, seccompProfile). Empty = no pod-level securityContext rendered.
+  podSecurityContext: {}
+  # containerSecurityContext sets container-level securityContext (e.g.
+  # runAsNonRoot, capabilities.drop, allowPrivilegeEscalation). Empty = none rendered.
+  containerSecurityContext: {}
 
 beatworker:
   replicas: 1
@@ -197,6 +233,12 @@ beatworker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # podSecurityContext sets pod-level securityContext (e.g. fsGroup,
+  # runAsUser, seccompProfile). Empty = no pod-level securityContext rendered.
+  podSecurityContext: {}
+  # containerSecurityContext sets container-level securityContext (e.g.
+  # runAsNonRoot, capabilities.drop, allowPrivilegeEscalation). Empty = none rendered.
+  containerSecurityContext: {}
 
 external_secrets:
   # Name of the existing Kubernetes Secret resource; see README for more details


### PR DESCRIPTION
## Summary

This PR exposes `securityContext` configuration via values for all 7
plane-ce workload deployments (admin, api, web, space, live, worker,
beatworker). Currently the chart renders no securityContext at all,
which means clusters with K8s PodSecurity Admission at `restricted` level
or any equivalent admission policy reject the pods.

## Behavior change

- **Default (values unset):** No change. The chart still renders
  templates without securityContext fields, matching today's behavior.
- **With values set:** Each workload gets pod-level and/or container-level
  securityContext as configured.

## Example values.yaml

```yaml
admin:
  podSecurityContext:
    runAsNonRoot: true
    runAsUser: 1000
    fsGroup: 1000
    seccompProfile:
      type: RuntimeDefault
  containerSecurityContext:
    privileged: false
    allowPrivilegeEscalation: false
    capabilities:
      drop: [ALL]
```

## Testing

- `helm template` with no values change: identical output to current.
- `helm template` with example values above: renders `securityContext:`
  block at both pod and container level on the rendered admin deployment.
- Verified against a cluster with K8s PSA `restricted` enforce mode +
  Kyverno's `pod-security-baseline` ClusterPolicy: pods are admitted
  when the example values are set, rejected when they're absent (current
  behavior).

## Why now

The current workaround for clusters that need this is to maintain a
namespace-wide Kyverno PolicyException — broad and hides actual
misconfigurations. With this change, operators can constrain individual
workloads precisely.

## Files changed

- `charts/plane-ce/templates/workloads/admin.deployment.yaml`
- `charts/plane-ce/templates/workloads/api.deployment.yaml`
- `charts/plane-ce/templates/workloads/web.deployment.yaml`
- `charts/plane-ce/templates/workloads/space.deployment.yaml`
- `charts/plane-ce/templates/workloads/live.deployment.yaml`
- `charts/plane-ce/templates/workloads/worker.deployment.yaml`
- `charts/plane-ce/templates/workloads/beat-worker.deployment.yaml`
- `charts/plane-ce/values.yaml` (add documented blank `podSecurityContext` /
  `containerSecurityContext` sections under each workload)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional pod-level and container-level security context configuration for admin, API, beat-worker, live, space, web, and worker deployments, allowing custom Kubernetes security settings to be applied per service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->