### PR TITLE
[INFRA-373]: add runner service to the helm charts

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.3.3
+version: 2.4.0
 appVersion: "2.5.4"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -81,6 +81,10 @@ data:
   {{- end }}
   PI_BASE_PATH: "/pi"
 
+  {{- if .Values.services.runner.enabled }}
+  RUNNER_BASE_URL: "http://{{ .Release.Name }}-runner.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}:3000"
+  {{- end }}
+
   {{- if .Values.airgapped.enabled }}
   IS_AIRGAPPED: "1"
   {{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/runner-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/runner-env.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.services.runner.enabled (empty .Values.external_secrets.runner_env_existingSecret)}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-runner-secrets
+stringData:
+  RUNNER_HMAC_SECRET_KEY: {{ .Values.env.runner_envs.hmac_secret_key | default "" | quote }}
+{{- end }}
+---
+{{- if .Values.services.runner.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-runner-vars
+data:
+  NODE_ENV: "production"
+  PORT: "3000"
+  EXECUTION_TIMEOUT_MS: {{ .Values.env.runner_envs.execution_timeout_ms | default "10000" | quote }}
+  INIT_TIMEOUT_MS: {{ .Values.env.runner_envs.init_timeout_ms | default "5000" | quote }}
+  ISOLATE_MEMORY_MB: {{ .Values.env.runner_envs.isolate_memory_mb | default "128" | quote }}
+  API_BASE_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}:8000"
+  CONTROL_SERVICE_BASE_URL: {{ .Values.env.runner_envs.control_service_base_url | default "" | quote }}
+{{- end }}
+---

--- a/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
@@ -1,0 +1,114 @@
+{{- if .Values.services.runner.enabled }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-runner
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-runner
+spec:
+  type: ClusterIP
+  {{- if not .Values.services.runner.assign_cluster_ip }}
+  clusterIP: None
+  {{- end }}
+  ports:
+  - name: runner-3000
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-runner
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-runner-wl
+  {{- include "plane.labelsAndAnnotations" .Values.services.runner }}
+spec:
+  replicas: {{ .Values.services.runner.replicas | default 1}}
+  selector:
+    matchLabels:
+      app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-runner
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-runner
+      annotations:
+        timestamp: {{ now | quote }}
+    spec:
+      {{- include "plane.podScheduling" .Values.services.runner }}
+      {{- with (include "plane.s3CANodeVolumes" .) }}
+{{ . | indent 6 }}
+      {{- end }}
+      {{- if include "plane.s3CAEnabled" . }}
+      initContainers:
+      - name: prepare-ca-bundle
+        image: busybox
+        command:
+          - /bin/sh
+          - -c
+          - |
+            set -e
+            echo "Preparing custom CA bundle for Node.js..."
+            if [ "$(ls -A /s3-custom-ca)" ]; then
+              cat /s3-custom-ca/* > /ca-bundle/custom-ca-bundle.crt
+              echo "CA bundle created at /ca-bundle/custom-ca-bundle.crt"
+            else
+              echo "No custom CA certificates found, creating empty bundle"
+              touch /ca-bundle/custom-ca-bundle.crt
+            fi
+        volumeMounts:
+          - name: s3-custom-ca
+            mountPath: /s3-custom-ca
+            readOnly: true
+          - name: ca-bundle
+            mountPath: /ca-bundle
+      {{- end }}
+      containers:
+      - name: {{ .Release.Name }}-runner
+        imagePullPolicy: {{ .Values.services.runner.pullPolicy | default "Always" }}
+        image: {{ .Values.services.runner.image | default "makeplane/node-runner-commercial" }}:{{ .Values.planeVersion }}
+        stdin: true
+        tty: true
+        resources:
+          requests:
+            memory: {{ .Values.services.runner.memoryRequest | default "128Mi" | quote }}
+            cpu: {{ .Values.services.runner.cpuRequest | default "100m" | quote }}
+          limits:
+            memory: {{ .Values.services.runner.memoryLimit | default "512Mi" | quote }}
+            cpu: {{ .Values.services.runner.cpuLimit | default "500m" | quote }}
+        {{- with (include "plane.s3CANodeBundleMount" .) }}
+{{ . | indent 8 }}
+        {{- end }}
+        readinessProbe:
+          tcpSocket:
+            port: 3000
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}-runner-vars
+              optional: false
+          - secretRef:
+              name: {{ if not (empty .Values.external_secrets.runner_env_existingSecret) }}{{ .Values.external_secrets.runner_env_existingSecret }}{{ else }}{{ .Release.Name }}-runner-secrets{{ end }}
+              optional: false
+        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        env:
+          {{- with (include "plane.s3CANodeEnvVars" .) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      serviceAccount: {{ .Release.Name }}-srv-account
+      serviceAccountName: {{ .Release.Name }}-srv-account
+---
+{{- end }}

--- a/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
@@ -42,33 +42,6 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.runner }}
-      {{- with (include "plane.s3CANodeVolumes" .) }}
-{{ . | indent 6 }}
-      {{- end }}
-      {{- if include "plane.s3CAEnabled" . }}
-      initContainers:
-      - name: prepare-ca-bundle
-        image: busybox
-        command:
-          - /bin/sh
-          - -c
-          - |
-            set -e
-            echo "Preparing custom CA bundle for Node.js..."
-            if [ "$(ls -A /s3-custom-ca)" ]; then
-              cat /s3-custom-ca/* > /ca-bundle/custom-ca-bundle.crt
-              echo "CA bundle created at /ca-bundle/custom-ca-bundle.crt"
-            else
-              echo "No custom CA certificates found, creating empty bundle"
-              touch /ca-bundle/custom-ca-bundle.crt
-            fi
-        volumeMounts:
-          - name: s3-custom-ca
-            mountPath: /s3-custom-ca
-            readOnly: true
-          - name: ca-bundle
-            mountPath: /ca-bundle
-      {{- end }}
       containers:
       - name: {{ .Release.Name }}-runner
         imagePullPolicy: {{ .Values.services.runner.pullPolicy | default "Always" }}
@@ -82,9 +55,6 @@ spec:
           limits:
             memory: {{ .Values.services.runner.memoryLimit | default "512Mi" | quote }}
             cpu: {{ .Values.services.runner.cpuLimit | default "500m" | quote }}
-        {{- with (include "plane.s3CANodeBundleMount" .) }}
-{{ . | indent 8 }}
-        {{- end }}
         readinessProbe:
           tcpSocket:
             port: 3000
@@ -99,14 +69,9 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.runner_env_existingSecret) }}{{ .Values.external_secrets.runner_env_existingSecret }}{{ else }}{{ .Release.Name }}-runner-secrets{{ end }}
               optional: false
-        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        {{- if .Values.extraEnv }}
         env:
-          {{- with (include "plane.s3CANodeEnvVars" .) }}
-{{ . | indent 10 }}
-          {{- end }}
-          {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 10 }}
-          {{- end }}
         {{- end }}
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -417,6 +417,22 @@ services:
     labels: {}
     annotations: {}
 
+  runner:
+    enabled: false
+    replicas: 1
+    memoryLimit: 512Mi
+    cpuLimit: 500m
+    memoryRequest: 128Mi
+    cpuRequest: 100m
+    image: makeplane/node-runner-commercial
+    pullPolicy: Always
+    assign_cluster_ip: false
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    labels: {}
+    annotations: {}
+
 external_secrets:
   # Name of the existing Kubernetes Secret resource; see README for more details
   rabbitmq_existingSecret: ''
@@ -427,6 +443,7 @@ external_secrets:
   live_env_existingSecret: ''
   silo_env_existingSecret: ''
   pi_api_env_existingSecret: ''
+  runner_env_existingSecret: ''
 
 env:
   storageClass: ''
@@ -516,6 +533,13 @@ env:
     event_stream_prefetch: 10
     exchange_name: "plane.event_stream"
     event_types: "issue"
+
+  runner_envs:
+    execution_timeout_ms: "10000"
+    init_timeout_ms: "5000"
+    isolate_memory_mb: "128"
+    control_service_base_url: ""
+    hmac_secret_key: ""
 
   pi_envs:
     plane_oauth:


### PR DESCRIPTION
### Description

Adds a new **node-runner** service to the `plane-enterprise` Helm chart. The runner is an isolated execution environment used by Plane for sandboxed code execution, and is exposed in-cluster on port `3000`.

**What's included:**

- **New deployment + service** (`templates/workloads/runner.deployment.yaml`) — `ClusterIP` Service (port `3000`) and Deployment running `makeplane/node-runner-commercial:<planeVersion>` with readiness probe, configurable replicas, resources, scheduling (nodeSelector / tolerations / affinity), labels and annotations.
- **Config + secrets** (`templates/config-secrets/runner-env.yaml`) — generates a `ConfigMap` (`<release>-runner-vars`) with non-sensitive runner env (`NODE_ENV`, `PORT`, `EXECUTION_TIMEOUT_MS`, `INIT_TIMEOUT_MS`, `ISOLATE_MEMORY_MB`, `API_BASE_URL`, `CONTROL_SERVICE_BASE_URL`) and a `Secret` (`<release>-runner-secrets`) for `RUNNER_HMAC_SECRET_KEY`. Supports BYO secret via `external_secrets.runner_env_existingSecret`.
- **App wiring** (`templates/config-secrets/app-env.yaml`) — injects `RUNNER_BASE_URL` into the main app env when the runner is enabled, pointing at the in-cluster runner service.
- **values.yaml** — adds `services.runner` block (disabled by default), `env.runner_envs` defaults, and `external_secrets.runner_env_existingSecret`.
- **Chart bump** — `plane-enterprise` chart version `2.3.3` → `2.4.0`.

The runner is **disabled by default** (`services.runner.enabled: false`) so this change is a no-op for existing installs until explicitly enabled.

### Type of Change
- [x] Feature (non-breaking change which adds functionality)

### Test Scenarios

- `helm template` / `helm lint` against `charts/plane-enterprise` with `services.runner.enabled=false` — no runner resources rendered, existing manifests unchanged.
- With `services.runner.enabled=true` — runner Deployment, Service, ConfigMap and Secret render; `RUNNER_BASE_URL` is injected into the app env ConfigMap.
- With `external_secrets.runner_env_existingSecret` set — the generated runner Secret is skipped and the Deployment's `envFrom` references the external secret.
- Verified the runner pod becomes Ready (TCP probe on `:3000`) and the API service can reach `http://<release>-runner.<namespace>.svc.<cluster_domain>:3000`.

### References

- INFRA-373