### PR TITLE
chore: scope pi body-limit to attachments path (keep upload cap + streaming)

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,9 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.4.3
+version: 2.4.4
 appVersion: "2.6.0"
+
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png
 sources:

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.4.4
+version: 2.4.5
 appVersion: "2.6.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.4.5
+version: 2.4.4
 appVersion: "2.6.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/templates/ingress-traefik.yaml
+++ b/charts/plane-enterprise/templates/ingress-traefik.yaml
@@ -80,6 +80,15 @@ spec:
   {{- end }}
 
   {{- if .Values.services.pi.enabled }}
+  # File uploads in pi: keep the body-size limit (more specific path matches first)
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/pi/api/v1/attachments/`)
+    kind: Rule
+    middlewares:
+      - name: {{ .Release.Name }}-body-limit
+    services:
+      - name: {{ .Release.Name }}-pi-api
+        port: 8000
+  # Everything else in pi (incl. streaming/SSE): no buffering middleware
   - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/pi/`)
     kind: Rule
     services:

--- a/charts/plane-enterprise/templates/ingress-traefik.yaml
+++ b/charts/plane-enterprise/templates/ingress-traefik.yaml
@@ -82,8 +82,6 @@ spec:
   {{- if .Values.services.pi.enabled }}
   - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/pi/`)
     kind: Rule
-    middlewares:
-      - name: {{ .Release.Name }}-body-limit
     services:
       - name: {{ .Release.Name }}-pi-api
         port: 8000


### PR DESCRIPTION
## What

Pi's `/pi/` route uses Traefik's `body-limit` middleware (`buffering.maxRequestBodyBytes`) to cap request size. That middleware reads the **entire request into memory before forwarding** and wraps the response, which breaks pi's streaming/SSE endpoints (chat) — the response only arrives once complete instead of streaming.

This PR keeps the upload size limit **without** breaking streaming by scoping the middleware to the upload path only.

## Changes

- **Split the pi route in two** (`templates/ingress-traefik.yaml`), ordered specific-first per the file's existing convention:
  - `PathPrefix(/pi/api/v1/attachments/)` → keeps the `body-limit` middleware (file uploads stay capped).
  - `PathPrefix(/pi/)` → no buffering middleware, so chat/SSE streaming flows uninterrupted.
- Bumped chart `version` to **2.4.5**.

The upload endpoint (`/api/v1/attachments/upload-attachment/`, confirmed via the network tab) lives under `/pi/api/v1/attachments/` in the self-hosted reverse-proxy layout, so all pi attachment traffic — the size-heavy path — retains the cap.

## Why this approach

Traefik's `buffering` middleware has no "limit size without buffering" option — size enforcement inherently requires reading the body, which is fundamentally incompatible with streaming on the same route. Path-splitting is the cleanest way to keep both behaviors at the edge.

## Notes

- The 20 MiB cap is still controlled by `ingress.traefik.maxRequestBodyBytes` in values.
- Confirmed the template renders correctly via `helm template`.
- Assumes the frontend calls pi uploads under the `/pi/` prefix on the license domain (self-hosted layout). If a deployment remaps/strips that prefix differently, the `PathPrefix` needs adjusting.
