### PR TITLE
fix: doc_upload_size_limit env override for FILE_SIZE_LIMIT

### DIFF
--- a/charts/plane-enterprise/templates/config-secrets/doc-store.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/doc-store.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-doc-store-secrets
 stringData:
-  FILE_SIZE_LIMIT: {{ .Values.env.file_size_limit | default "5242880" | quote }}
+  FILE_SIZE_LIMIT: {{ .Values.env.doc_upload_size_limit | default "5242880" | quote }}
   AWS_S3_BUCKET_NAME: {{ .Values.env.docstore_bucket | default "" | quote  }}
   {{- if .Values.services.minio.local_setup }}
   USE_MINIO: "1"


### PR DESCRIPTION
## Summary
Fixes makeplane/plane#9035

The `env.doc_upload_size_limit` value in the Plane Enterprise Helm chart was not correctly overriding the `FILE_SIZE_LIMIT` environment variable. Users had to use the undocumented `env.file_size_limit` key instead.

## Root Cause
The `plane-enterprise` chart template (`charts/plane-enterprise/templates/config-secrets/doc-store.yaml`) incorrectly referenced `.Values.env.file_size_limit` instead of `.Values.env.doc_upload_size_limit`. Meanwhile, the `values.yaml`, `README.md`, and `questions.yml` all documented the key as `env.doc_upload_size_limit`. The `plane-ce` chart already had the correct mapping.

## Fix
Changed line 9 of `charts/plane-enterprise/templates/config-secrets/doc-store.yaml` from:
```
FILE_SIZE_LIMIT: {{ .Values.env.file_size_limit | default "5242880" | quote }}
```
to:
```
FILE_SIZE_LIMIT: {{ .Values.env.doc_upload_size_limit | default "5242880" | quote }}
```

## Changes
- `charts/plane-enterprise/templates/config-secrets/doc-store.yaml`: Fixed env var reference (+1 -1 lines)

## Testing
- **`env.doc_upload_size_limit: "104857600"`**: Renders `FILE_SIZE_LIMIT: "104857600"` ✅
- **`env.file_size_limit: "104857600"` (old key)**: Renders default `FILE_SIZE_LIMIT: "5242880"` ✅ (no longer used)
- **No value set**: Renders default `FILE_SIZE_LIMIT: "5242880"` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated document upload size limit configuration sourcing in deployment settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/helm-charts/pull/227)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->