### PR TITLE
[INFRA-373]: enforce non-empty RUNNER_HMAC_SECRET_KEY for runner

### DIFF
--- a/charts/plane-enterprise/templates/config-secrets/runner-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/runner-env.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-runner-secrets
 stringData:
-  RUNNER_HMAC_SECRET_KEY: {{ .Values.env.runner_envs.hmac_secret_key | default "" | quote }}
+  RUNNER_HMAC_SECRET_KEY: {{ required "env.runner_envs.hmac_secret_key must be set when services.runner.enabled=true and external_secrets.runner_env_existingSecret is empty" .Values.env.runner_envs.hmac_secret_key | quote }}
 {{- end }}
 ---
 {{- if .Values.services.runner.enabled }}


### PR DESCRIPTION
### Description

Follow-up to #225. Addresses the CodeRabbit review comment that the runner-env Secret was rendering an empty `RUNNER_HMAC_SECRET_KEY` whenever `services.runner.enabled=true` and no external secret was provided, which is an unsafe default and silently breaks HMAC auth/signature guarantees.

This change replaces the `default ""` with Helm's `required` function on `.Values.env.runner_envs.hmac_secret_key`, so `helm template` / `helm install` fails fast with a clear message when the value is missing — and only when the internal secret is actually being rendered (the `required` is gated by the existing `if and .Values.services.runner.enabled (empty .Values.external_secrets.runner_env_existingSecret)` block).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

Verified via `helm template charts/plane-enterprise`:

1. **Runner disabled (default)** — no runner resources rendered; chart renders cleanly.
2. **Runner enabled, `hmac_secret_key` not set, no external secret** — fails fast with:
   `Error: execution error at (.../runner-env.yaml:9:29): env.runner_envs.hmac_secret_key must be set when services.runner.enabled=true and external_secrets.runner_env_existingSecret is empty`
3. **Runner enabled, `hmac_secret_key` set** — Secret renders with the provided value.
4. **Runner enabled, `external_secrets.runner_env_existingSecret` set** — internal Secret is skipped (no `required` triggered); Deployment references the external secret as before.

### References

- INFRA-373
- Follow-up to #225 (CodeRabbit review comment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Runner service configuration now enforces that the HMAC secret key must be explicitly provided, eliminating the possibility of an empty fallback value that could cause issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/helm-charts/pull/228)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->