### PR TITLE
Fix swagger static ingress

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.5.1
+version: 1.5.2
 appVersion: "1.3.1"
 
 home: https://plane.so

--- a/charts/plane-ce/templates/ingress-traefik.yaml
+++ b/charts/plane-ce/templates/ingress-traefik.yaml
@@ -45,6 +45,14 @@ spec:
       - name: {{ .Release.Name }}-api
         port: 8000
 
+  - match: Host(`{{ .Values.ingress.appHost }}`) && PathPrefix(`/static`)
+    kind: Rule
+    middlewares:
+      - name: {{ .Release.Name }}-body-limit
+    services:
+      - name: {{ .Release.Name }}-api
+        port: 8000
+
   - match: Host(`{{ .Values.ingress.appHost }}`) && PathPrefix(`/live`)
     kind: Rule
     middlewares:

--- a/charts/plane-ce/templates/ingress.yaml
+++ b/charts/plane-ce/templates/ingress.yaml
@@ -41,6 +41,13 @@ spec:
           - backend:
               service:
                 port:
+                  number: 8000
+                name: {{ .Release.Name }}-api
+            path: /static
+            pathType: Prefix
+          - backend:
+              service:
+                port:
                   number: 3000
                 name: {{ .Release.Name }}-live
             path: /live/

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.4.3
+version: 2.4.4
 appVersion: "2.6.0"
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/templates/ingress-traefik.yaml
+++ b/charts/plane-enterprise/templates/ingress-traefik.yaml
@@ -45,6 +45,14 @@ spec:
       - name: {{ .Release.Name }}-api
         port: 8000
 
+  - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/static/`)
+    kind: Rule
+    middlewares:
+      - name: {{ .Release.Name }}-body-limit
+    services:
+      - name: {{ .Release.Name }}-api
+        port: 8000
+
   - match: Host(`{{ .Values.license.licenseDomain }}`) && PathPrefix(`/graphql/`)
     kind: Rule
     middlewares:

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -55,6 +55,13 @@ spec:
           - backend:
               service:
                 port:
+                  number: 8000
+                name: {{ .Release.Name }}-api
+            path: /static/
+            pathType: Prefix
+          - backend:
+              service:
+                port:
                   number: 3000
                 name: {{ .Release.Name }}-live
             path: /live/


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This pull request updates both the Community Edition and Enterprise Helm charts for Plane with minor version bumps and improved ingress routing for static file handling. The main changes ensure that requests to the `/static` path are correctly routed to the backend service in both NGINX and Traefik ingress configurations.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->

- [X] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plane-ce Helm chart to v1.5.2
  * Updated plane-enterprise Helm chart to v2.4.4
  * Enhanced ingress routing configuration for improved content delivery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/helm-charts/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->