### PR TITLE
docs(plane-enterprise): document nginx proxy-buffer-size ingress annotation

### DIFF
--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -40,8 +40,12 @@ ingress:
   rabbitmqHost: ''
   ingressClass: 'traefik'
   # If using nginx ingress controller, set this to 'nginx' and add the appropriate annotations to set the proxy body size limit.
-  # For nginx ingress controller, you can set the proxy body size limit using annotations. Example:
-  # ingress_annotations: { "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }
+  # These annotations are ONLY rendered when ingressClass is 'nginx' (the nginx Ingress template is gated on
+  # ingressClass == "nginx"); they have no effect with traefik. Example:
+  # - proxy-body-size: nginx equivalent of traefik's maxRequestBodyBytes (upload size limit).
+  # - proxy-buffer-size: size of the buffer for the response headers from upstream; bump this to avoid
+  #   "502 upstream sent too big header" errors.
+  # ingress_annotations: { "nginx.ingress.kubernetes.io/proxy-body-size": "5m", "nginx.ingress.kubernetes.io/proxy-buffer-size": "16k" }
   traefik:
     maxRequestBodyBytes: 20971520 # in bytes (default: 20 MiB)
 


### PR DESCRIPTION
## What

Extends the commented-out `ingress_annotations` example in `charts/plane-enterprise/values.yaml` to include the nginx `proxy-buffer-size` annotation alongside the existing `proxy-body-size`, and adds clarifying comments about scope.

```yaml
# ingress_annotations: { "nginx.ingress.kubernetes.io/proxy-body-size": "5m", "nginx.ingress.kubernetes.io/proxy-buffer-size": "16k" }
```

## Why

- `nginx.ingress.kubernetes.io/proxy-buffer-size` sizes the buffer used for **response headers from upstream**. Bumping it (e.g. `16k`) is the standard fix for `502 upstream sent too big header` errors that can occur when an upstream returns large headers (e.g. big auth/cookie payloads).
- The previous example only documented `proxy-body-size`, so operators on nginx had no in-chart hint for tuning header buffers.

## Scope / behavior

- **No default behavior change.** The annotations remain commented out, exactly as before — nothing is applied unless an operator uncomments and sets `ingress_annotations`.
- **nginx-only by design.** `templates/ingress.yaml` is gated on `ingressClass == "nginx"` and is the only template that renders `ingress_annotations`, so these annotations have no effect under traefik.

## Traefik note

There is no per-route equivalent of nginx's `proxy-buffer-size` in Traefik. The `Middleware.buffering` spec (already used via `ingress.traefik.maxRequestBodyBytes`) only controls request/response **body** limits — the analog of `proxy-body-size`. Response **header** buffering in Traefik is handled by the underlying Go HTTP server (~1 MB default) and tuned via static/entrypoint config, not a per-route middleware. So no Traefik template change is needed for this.

## Testing

`helm template` verified:
- `ingressClass=nginx` → both `proxy-body-size` and `proxy-buffer-size` render under `metadata.annotations` when the example is uncommented.
- `ingressClass=traefik` → nginx Ingress renders empty; annotations not applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)