### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chart-preview.yml
+++ b/.github/workflows/chart-preview.yml
@@ -14,6 +14,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 env:
   PREVIEW_BUILD_FOLDER: helm-preview
   AWS_ACCESS_KEY_ID: ${{ secrets.HELM_PREVIEW_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Potential fix for [https://github.com/makeplane/helm-charts/security/code-scanning/1](https://github.com/makeplane/helm-charts/security/code-scanning/1)

Add an explicit workflow-level `permissions` block with least privilege, immediately after the `on:` section (or before `env:`). For this workflow, the safest minimal non-breaking setting is:

- `contents: read`

This preserves checkout functionality while preventing broader implicit token access. No imports, methods, or dependencies are needed since this is a YAML workflow config change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to explicitly set repository-level read access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->