### PR TITLE
feat(plane-enterprise): add opt-in PSA restricted securityContext

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.4.5
+version: 2.5.0
 appVersion: "2.6.1"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -211,6 +211,53 @@ airgapped:
   # s3SecretName and s3SecretKey can be removed after migration
 ```
 
+### Pod Security (PSA `restricted`)
+
+Plane's first-party images run as non-root, so the chart can render a hardened
+pod- and container-level `securityContext` that satisfies the Kubernetes
+[Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
+`restricted` profile. This is the Helm equivalent of the kustomize
+`nonroot-security-context` component, and is **opt-in** (`securityContext.enabled=false`
+by default) so existing installs are unchanged.
+
+When enabled, the context is applied to all first-party Plane workloads (api, web,
+space, admin, live, worker, beat-worker, automation-consumer, outbox-poller, silo,
+monitor, iframely, runner, pi-api/beat/worker, and the migration Jobs — including
+their busybox init containers).
+
+It is **not** applied to the bundled local infrastructure (postgres, redis, rabbitmq,
+minio, opensearch), which use third-party images with their own UID/GID requirements
+and are intended for local/dev use — run those externally in hardened clusters and
+leave `local_setup` off. The email service also keeps its own `securityContext`
+(its image pins UID 100).
+
+| Setting                                  |     Default      | Required | Description                                                                                    |
+| ---------------------------------------- | :--------------: | :------: | ---------------------------------------------------------------------------------------------- |
+| securityContext.enabled                  |      false       |    No    | Master switch. When `true`, renders the pod- and container-level `securityContext` blocks.     |
+| securityContext.podSecurityContext       | see `values.yaml`|    No    | Map rendered at `spec.template.spec.securityContext`. Defaults to PSA `restricted` settings.   |
+| securityContext.containerSecurityContext | see `values.yaml`|    No    | Map rendered at each container's/initContainer's `securityContext`. PSA `restricted` defaults. |
+
+Enable with PSA-restricted defaults (UID/GID `1000`):
+
+```bash
+helm upgrade --install plane-app plane/plane-enterprise \
+    --namespace plane \
+    --set securityContext.enabled=true
+```
+
+To pin a specific UID (e.g. `10001`), override the relevant keys:
+
+```yaml
+securityContext:
+  enabled: true
+  podSecurityContext:
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+  containerSecurityContext:
+    runAsUser: 10001
+```
+
 ### Docker Registry
 
 | Setting                      | Default              | Required | Description                                                                                                                                                                                                                                                                                                                        |

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -18,6 +18,30 @@
   {{- end }}
 {{- end }}
 
+{{/*
+Pod-level securityContext. Rendered only when securityContext.enabled is true.
+Mirrors the kustomize nonroot-security-context component (pod patch).
+Place inside spec.template.spec — call with the root context, e.g.
+  {{- include "plane.podSecurityContext" . }}
+*/}}
+{{- define "plane.podSecurityContext" -}}
+{{- if .Values.securityContext.enabled }}
+      securityContext: {{- toYaml .Values.securityContext.podSecurityContext | nindent 8 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Container-level securityContext. Rendered only when securityContext.enabled is true.
+Mirrors the kustomize nonroot-security-context component (container patch).
+Place inside a container/initContainer entry — call with the root context, e.g.
+  {{- include "plane.containerSecurityContext" . }}
+*/}}
+{{- define "plane.containerSecurityContext" -}}
+{{- if .Values.securityContext.enabled }}
+        securityContext: {{- toYaml .Values.securityContext.containerSecurityContext | nindent 10 }}
+{{- end }}
+{{- end -}}
+
 {{- define "plane.labelsAndAnnotations" -}}
   {{- with .labels }}
   labels: {{ toYaml . | nindent 4 }}

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -41,8 +41,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.admin }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-admin
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.admin.pullPolicy | default "Always" }}
         image: {{ .Values.services.admin.image | default "makeplane/admin-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -41,11 +41,13 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.api }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CAVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-api
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.api.pullPolicy | default "Always" }}
         image: {{ .Values.services.api.image | default "makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
@@ -19,8 +19,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.automation_consumer }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-automation-consumer
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: Always
         image: {{ .Values.services.api.image | default "makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -18,8 +18,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.beatworker }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-beat-worker
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy:  {{ .Values.services.api.pullPolicy | default "Always" }}
         image: {{ .Values.services.api.image | default "makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
@@ -38,8 +38,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.iframely }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-iframely
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: Always
         image: {{ .Values.services.iframely.image | default "makeplane/iframely:v1.2.0" }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -41,6 +41,7 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.live }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CANodeVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
@@ -48,6 +49,7 @@ spec:
       initContainers:
       - name: prepare-ca-bundle
         image: busybox
+        {{- include "plane.containerSecurityContext" . }}
         command:
           - /bin/sh
           - -c
@@ -70,6 +72,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-live
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.live.pullPolicy | default "Always" }}
         image: {{ .Values.services.live.image | default "makeplane/live-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/migrator.job.yaml
@@ -15,8 +15,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.api }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-api-migrate
+        {{- include "plane.containerSecurityContext" . }}
         image: {{ .Values.services.api.image | default "makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
         command: 
           - ./bin/docker-entrypoint-migrator.sh

--- a/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
@@ -38,8 +38,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.monitor }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - image: {{ .Values.services.monitor.image | default "makeplane/monitor-commercial" }}:{{ .Values.planeVersion }}
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.monitor.pullPolicy | default "Always" }}
         name: {{ .Release.Name }}-monitor
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
@@ -19,8 +19,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.outbox_poller }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-outbox-poller
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: Always
         image: {{ .Values.services.api.image | default "makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
@@ -42,11 +42,13 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CAVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-pi-api
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.pi.pullPolicy | default "Always" }}
         image: {{ .Values.services.pi.image | default "makeplane/plane-pi-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
@@ -19,11 +19,13 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi_beat_worker }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CAVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-pi-beat
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: Always
         image: {{ .Values.services.pi.image | default "makeplane/plane-pi-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/pi-migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-migrator.job.yaml
@@ -15,11 +15,13 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CAVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-pi-api-migrate
+        {{- include "plane.containerSecurityContext" . }}
         image: {{ .Values.services.pi.image | default "makeplane/plane-pi-commercial" }}:{{ .Values.planeVersion }}
         imagePullPolicy: Always
         {{- with (include "plane.s3CAVolumeMounts" .) }}

--- a/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
@@ -19,11 +19,13 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi_worker }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CAVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-pi-worker
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: Always
         image: {{ .Values.services.pi.image | default "makeplane/plane-pi-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
@@ -42,8 +42,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.runner }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-runner
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.runner.pullPolicy | default "Always" }}
         image: {{ .Values.services.runner.image | default "makeplane/node-runner-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -42,12 +42,14 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.silo }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CANodeVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
       initContainers:
       - name: wait-for-rabbitmq
         image: busybox
+        {{- include "plane.containerSecurityContext" . }}
         command:
           - /bin/sh
         args:
@@ -70,6 +72,7 @@ spec:
       {{- if include "plane.s3CAEnabled" . }}
       - name: prepare-ca-bundle
         image: busybox
+        {{- include "plane.containerSecurityContext" . }}
         command:
           - /bin/sh
           - -c
@@ -92,6 +95,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-silo
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: Always
         image: {{ .Values.services.silo.image | default "makeplane/silo-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -41,8 +41,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.space }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-space
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.space.pullPolicy | default "Always" }}
         image: {{ .Values.services.space.image | default "makeplane/space-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -41,8 +41,10 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.web }}
+      {{- include "plane.podSecurityContext" . }}
       containers:
       - name: {{ .Release.Name }}-web
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.web.pullPolicy | default "Always" }}
         image: {{ .Values.services.web.image | default "makeplane/web-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -18,11 +18,13 @@ spec:
         timestamp: {{ now | quote }}
     spec:
       {{- include "plane.podScheduling" .Values.services.worker }}
+      {{- include "plane.podSecurityContext" . }}
       {{- with (include "plane.s3CAVolumes" .) }}
 {{ . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-worker
+        {{- include "plane.containerSecurityContext" . }}
         imagePullPolicy: {{ .Values.services.api.pullPolicy | default "Always" }}
         image: {{ .Values.services.api.image | default "makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
         stdin: true

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -59,6 +59,46 @@ ssl:
   email: plane@example.com
   generateCerts: false
 
+# ============================================================
+# Pod Security (Kubernetes Pod Security Admission "restricted")
+# ============================================================
+# When enabled, applies a hardened pod- and container-level securityContext to
+# all first-party Plane workloads: api, web, space, admin, live, worker,
+# beat-worker, automation-consumer, outbox-poller, silo, monitor, iframely,
+# runner, pi-api/beat/worker, and the migration Jobs (including their busybox
+# init containers). Plane's images run fine as non-root, so these defaults
+# satisfy the PSA "restricted" profile.
+#
+# NOT applied to:
+#   - The bundled local infrastructure (postgres, redis, rabbitmq, minio,
+#     opensearch): third-party images with their own UID/GID requirements,
+#     intended for local/dev use. In hardened clusters run those externally
+#     (managed RDS, ElastiCache, etc.) and leave local_setup off.
+#   - The email service: its image pins UID 100 and keeps its own securityContext.
+#
+# Mirrors the kustomize `nonroot-security-context` component. Override runAsUser/
+# runAsGroup/fsGroup below if your environment pins a specific UID (e.g. 10001).
+securityContext:
+  enabled: false
+  # Rendered at spec.template.spec.securityContext (pod level).
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  # Rendered at each container's / initContainer's securityContext.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
 services:
   redis:
     local_setup: true


### PR DESCRIPTION
## What

Adds a configurable, **opt-in** pod- and container-level `securityContext` to the `plane-enterprise` chart so workloads can satisfy the Kubernetes Pod Security Admission (PSA) `restricted` profile. This is the Helm equivalent of the kustomize `nonroot-security-context` component.

New top-level block in `values.yaml` (defaults shown, UID/GID overridable):

```yaml
securityContext:
  enabled: false            # opt-in; off = no change to existing installs
  podSecurityContext:       # -> spec.template.spec.securityContext
    runAsNonRoot: true
    runAsUser: 1000
    runAsGroup: 1000
    fsGroup: 1000
    seccompProfile: { type: RuntimeDefault }
  containerSecurityContext: # -> each container's securityContext
    allowPrivilegeEscalation: false
    runAsNonRoot: true
    runAsUser: 1000
    capabilities: { drop: ["ALL"] }
    seccompProfile: { type: RuntimeDefault }
```

Implemented via two helpers in `_helpers.tpl` (`plane.podSecurityContext`, `plane.containerSecurityContext`) that render only when `enabled: true`, wired into every first-party workload. Chart version bumped `2.4.5 → 2.5.0`.

## Why

Customers running Plane in hardened clusters want pods to pass PSA `restricted` admission (non-root, no privilege escalation, all capabilities dropped, `RuntimeDefault` seccomp). Plane's first-party images already run fine as non-root, but the Helm chart previously had no way to express this — the only option was forking templates or post-render patching. Kustomize users already get this via the `nonroot-security-context` component; this brings the chart to parity.

## Scope / behavior

- **Opt-in, zero default change.** `enabled: false` by default. With it off, the helpers render nothing — pod specs are byte-identical to before, so upgrading the chart alone is a no-op (verified: `helm template` produces 0 `securityContext` blocks from this feature when disabled).
- **Covered (when enabled):** api, web, space, admin, live, worker, beat-worker, automation-consumer, outbox-poller, silo, monitor, iframely, runner, pi-api/beat/worker, and the migration Jobs — **including the busybox init containers** in live/silo, so a `restricted`-enforced namespace actually admits the pods.
- **Intentionally excluded:**
  - Bundled local infra (postgres, redis, rabbitmq, minio, opensearch) — third-party images with their own UID/GID needs, dev-only; run externally in hardened clusters.
  - `email` service — its image pins UID 100 and binds SMTP low ports (25/587/465), which `capabilities.drop: ["ALL"]` would prevent; it keeps its own `securityContext`.

## Testing

`helm lint` clean; `helm template` renders + parses (YAML valid) with the feature on and off; UID override to `10001` confirmed to flow through.

**Live upgrade test on EKS** (`plane-eks-dev`, namespace `gp`, external RDS):
1. Installed the **baseline** chart (HEAD, no feature) — all 12 workloads `Running 1/1`, jobs `Completed`, pods running as **uid=0 (root)**.
2. `helm upgrade` to this branch with `--set securityContext.enabled=true` — all pods `Running 1/1`, **0 restarts**, no `runAsNonRoot` admission rejections.

Observed after upgrade:
- App pods now non-root: `api`/`web`/`worker`/`silo` → `uid=1000`, `live` → `uid=1000(node)`.
- Pod + container `securityContext` applied as configured (verified via `kubectl get pod -o jsonpath`).
- silo busybox `wait-for-rabbitmq` init container terminated `exitCode 0` under the restricted context.
- `monitor` StatefulSet (PVC + `fsGroup`) came back `Ready` with no permission/chown issue.
- Infra (`redis`/`rabbitmq`/`minio`) `securityContext: {}` and **not restarted** — exclusion confirmed.
- API serving `GET / → 200`; migration Job `succeeded`.

## Upgrade notes

Existing installs are unaffected unless they explicitly set `securityContext.enabled=true`. When enabling on an existing install: stateless deployments do a rolling restart as UID 1000; the only first-party StatefulSet with a PVC (`monitor`, ~100Mi) is re-owned via `fsGroup` on restart (safe, verified). Bundled infra PVCs are untouched. If overriding `runAsUser`, ensure the value is one the images can use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional hardened security context configuration across all workloads, enabling Pod Security Admission "restricted" profile compliance.
  * Supports non-root execution, fixed UID/GID defaults, seccomp profile enforcement, and disabled privilege escalation.

* **Documentation**
  * Added documentation for pod security hardening options, air-gapped settings, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->