### PR TITLE
feat(plane-enterprise): native OpenTelemetry APM support (v2.5.1)

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.7.0
+version: 2.8.0
 appVersion: "2.6.3"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -242,3 +242,61 @@ Caller must nindent to the correct depth.
   value: "/ca-bundle/custom-ca-bundle.crt"
 {{- end }}
 {{- end -}}
+
+{{/*
+OpenTelemetry inline env vars for a single workload.
+
+The Django backend (api, worker, beat-worker, automation-consumer, outbox-poller,
+migrator) already sources the shared OTEL_* config from the app-vars ConfigMap
+(see config-secrets/app-env.yaml). This helper renders those same keys INLINE so
+that services which do NOT consume app-vars — the Node services (silo, live), the
+SSR frontend (space) and Plane Intelligence (pi-api, pi-worker, pi-beat) — get
+full OTel coverage, and so every workload can report its own OTEL_SERVICE_NAME
+(inline env wins over envFrom). Kept in sync with the OTEL block in app-env.yaml.
+
+Call with a dict carrying the root context and the per-service name:
+  {{- include "plane.otelServiceEnv" (dict "context" $ "service" "silo") }}
+Pass "full" false to emit ONLY the OTEL_SERVICE_NAME override — used by Django
+workloads that already get the rest of the OTEL_* keys from app-vars.
+Caller must indent to the correct depth (matches the s3CA*EnvVars pattern).
+*/}}
+{{- define "plane.otelServiceEnv" -}}
+{{- $ctx := .context -}}
+{{- $otel := $ctx.Values.observability.otel -}}
+{{- if $otel.enabled -}}
+- name: OTEL_SERVICE_NAME
+  value: {{ .service | quote }}
+{{- if not (eq .full false) }}
+- name: OTEL_ENABLED
+  value: "1"
+{{- if $otel.endpoint }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ $otel.endpoint | quote }}
+{{- else if $otel.collector.enabled }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: "http://{{ $ctx.Release.Name }}-otel-collector.{{ $ctx.Release.Namespace }}.svc.cluster.local:4317"
+{{- else }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: ""
+{{- end }}
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: {{ $otel.protocol | default "grpc" | quote }}
+- name: OTEL_TRACES_SAMPLER
+  value: {{ $otel.tracesSampler | default "parentbased_traceidratio" | quote }}
+- name: OTEL_TRACES_SAMPLER_ARG
+  value: {{ $otel.tracesSamplerArg | default "0.1" | quote }}
+{{- if $otel.resourceAttributes }}
+- name: OTEL_RESOURCE_ATTRIBUTES
+  value: {{ $otel.resourceAttributes | quote }}
+{{- end }}
+{{- if $otel.debugConsole }}
+- name: OTEL_DEBUG_CONSOLE
+  value: "1"
+{{- end }}
+{{- if $otel.headers }}
+- name: OTEL_EXPORTER_OTLP_HEADERS
+  value: {{ $otel.headers | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -274,7 +274,7 @@ Caller must indent to the correct depth (matches the s3CA*EnvVars pattern).
   value: {{ $otel.endpoint | quote }}
 {{- else if $otel.collector.enabled }}
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
-  value: "http://{{ $ctx.Release.Name }}-otel-collector.{{ $ctx.Release.Namespace }}.svc.cluster.local:4317"
+  value: "http://{{ $ctx.Release.Name }}-otel-collector.{{ $ctx.Release.Namespace }}.svc.{{ $ctx.Values.env.default_cluster_domain | default "cluster.local" }}:{{ eq ($otel.protocol | default "grpc") "grpc" | ternary "4317" "4318" }}"
 {{- else }}
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
   value: ""

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -123,7 +123,8 @@ data:
   {{- if .Values.observability.otel.endpoint }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.observability.otel.endpoint | quote }}
   {{- else if .Values.observability.otel.collector.enabled }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://{{ .Release.Name }}-otel-collector.{{ .Release.Namespace }}.svc.cluster.local:4317"
+  {{- $collectorPort := eq (.Values.observability.otel.protocol | default "grpc") "grpc" | ternary "4317" "4318" }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://{{ .Release.Name }}-otel-collector.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}:{{ $collectorPort }}"
   {{- else }}
   OTEL_EXPORTER_OTLP_ENDPOINT: ""
   {{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -133,4 +133,17 @@ data:
   {{- if .Values.observability.otel.resourceAttributes }}
   OTEL_RESOURCE_ATTRIBUTES: {{ .Values.observability.otel.resourceAttributes | quote }}
   {{- end }}
+  {{- if .Values.observability.otel.debugConsole }}
+  OTEL_DEBUG_CONSOLE: "1"
+  {{- end }}
+  {{- /* Browser/client tracing. Read ONLY by the API, which serves it to the
+         web/admin/space browsers via its public instance config — a no-op env on
+         every other workload, so it lives here on the API's app-vars alone. */}}
+  {{- if .Values.observability.otel.frontend.enabled }}
+  FRONTEND_OTEL_ENABLED: "1"
+  FRONTEND_OTLP_ENDPOINT: {{ .Values.observability.otel.frontend.endpoint | default .Values.observability.otel.endpoint | quote }}
+  {{- if .Values.observability.otel.frontend.headers }}
+  FRONTEND_OTLP_HEADERS: {{ .Values.observability.otel.frontend.headers | quote }}
+  {{- end }}
+  {{- end }}
   {{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -45,6 +45,10 @@ stringData:
   {{- if include "plane.s3CAEnabled" . }}
   AWS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
   {{- end }}
+
+  {{- if and .Values.observability.otel.enabled .Values.observability.otel.headers }}
+  OTEL_EXPORTER_OTLP_HEADERS: {{ .Values.observability.otel.headers | quote }}
+  {{- end }}
 {{- end }}
 ---
 
@@ -107,4 +111,26 @@ data:
   CORS_ALLOWED_ORIGINS: "http://{{ .Values.license.licenseDomain }},https://{{ .Values.license.licenseDomain }},{{ .Values.env.cors_allowed_origins }}"
   {{- else}}
   CORS_ALLOWED_ORIGINS: "http://{{ .Values.license.licenseDomain }},https://{{ .Values.license.licenseDomain }}"
+  {{- end }}
+
+  {{- /* OpenTelemetry APM for the Django backend (api, worker, beat-worker,
+         automation-consumer, outbox-poller, migrator). No-op in the app unless
+         OTEL_ENABLED=1 and an endpoint is set. Auth headers, if any, live in the
+         app-secrets Secret above. See docs/otel-api-observability in plane-ee. */}}
+  {{- if .Values.observability.otel.enabled }}
+  OTEL_ENABLED: "1"
+  OTEL_SERVICE_NAME: {{ .Values.observability.otel.serviceName | default "plane-api" | quote }}
+  {{- if .Values.observability.otel.endpoint }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.observability.otel.endpoint | quote }}
+  {{- else if .Values.observability.otel.collector.enabled }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://{{ .Release.Name }}-otel-collector.{{ .Release.Namespace }}.svc.cluster.local:4317"
+  {{- else }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: ""
+  {{- end }}
+  OTEL_EXPORTER_OTLP_PROTOCOL: {{ .Values.observability.otel.protocol | default "grpc" | quote }}
+  OTEL_TRACES_SAMPLER: {{ .Values.observability.otel.tracesSampler | default "parentbased_traceidratio" | quote }}
+  OTEL_TRACES_SAMPLER_ARG: {{ .Values.observability.otel.tracesSamplerArg | default "0.1" | quote }}
+  {{- if .Values.observability.otel.resourceAttributes }}
+  OTEL_RESOURCE_ATTRIBUTES: {{ .Values.observability.otel.resourceAttributes | quote }}
+  {{- end }}
   {{- end }}

--- a/charts/plane-enterprise/templates/observability/otel-collector.yaml
+++ b/charts/plane-enterprise/templates/observability/otel-collector.yaml
@@ -78,7 +78,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-otel-collector
-  {{- include "plane.labelsAndAnnotations" .Values.observability.otel.collector }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.observability.otel.collector) }}
 spec:
   replicas: {{ .Values.observability.otel.collector.replicas | default 1 }}
   selector:

--- a/charts/plane-enterprise/templates/observability/otel-collector.yaml
+++ b/charts/plane-enterprise/templates/observability/otel-collector.yaml
@@ -1,0 +1,120 @@
+{{- /*
+  Bundled OpenTelemetry Collector. Rendered only when OTEL is enabled AND the
+  bundled collector is requested. Self-hosters pointing at an external collector
+  (Datadog Agent, Grafana Cloud, an existing cluster collector) leave
+  observability.otel.collector.enabled=false and these resources are omitted.
+
+  When enabled with an empty observability.otel.endpoint, the backend auto-targets
+  this collector's in-cluster Service (see config-secrets/app-env.yaml).
+*/}}
+{{- if and .Values.observability.otel.enabled .Values.observability.otel.collector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-otel-collector-config
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-otel-collector
+data:
+  config.yaml: |
+{{- if .Values.observability.otel.collector.config }}
+{{ .Values.observability.otel.collector.config | indent 4 }}
+{{- else }}
+    # Default pipeline: receive OTLP, log via `debug`. Override the whole config
+    # with observability.otel.collector.config to export to a real backend.
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch:
+        timeout: 10s
+        send_batch_size: 1024
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+{{- end }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-otel-collector
+  labels:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-otel-collector
+spec:
+  type: ClusterIP
+  ports:
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-otel-collector
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-otel-collector
+  {{- include "plane.labelsAndAnnotations" .Values.observability.otel.collector }}
+spec:
+  replicas: {{ .Values.observability.otel.collector.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-otel-collector
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-otel-collector
+      annotations:
+        timestamp: {{ now | quote }}
+    spec:
+      {{- include "plane.podScheduling" .Values.observability.otel.collector }}
+      containers:
+      - name: {{ .Release.Name }}-otel-collector
+        imagePullPolicy: {{ .Values.observability.otel.collector.pullPolicy | default "IfNotPresent" }}
+        image: {{ .Values.observability.otel.collector.image | default "otel/opentelemetry-collector-contrib:0.115.1" }}
+        args: ["--config=/etc/otel/config.yaml"]
+        ports:
+        - name: otlp-grpc
+          containerPort: 4317
+        - name: otlp-http
+          containerPort: 4318
+        resources:
+          requests:
+            memory: {{ .Values.observability.otel.collector.memoryRequest | default "128Mi" | quote }}
+            cpu: {{ .Values.observability.otel.collector.cpuRequest | default "100m" | quote }}
+          limits:
+            memory: {{ .Values.observability.otel.collector.memoryLimit | default "512Mi" | quote }}
+            cpu: {{ .Values.observability.otel.collector.cpuLimit | default "500m" | quote }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/otel
+      volumes:
+      - name: config
+        configMap:
+          name: {{ .Release.Name }}-otel-collector-config
+{{- end }}

--- a/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
@@ -53,9 +53,14 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.opensearch_existingSecret) }}{{ .Values.external_secrets.opensearch_existingSecret }}{{ else }}{{ .Release.Name }}-opensearch-secrets{{ end }}
               optional: false
-        {{- if .Values.extraEnv }}
+        {{- if or .Values.extraEnv .Values.observability.otel.enabled }}
         env:
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "automation-consumer" "full" false)) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 10 }}
+          {{- end }}
         {{- end }}
 
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -54,9 +54,14 @@ spec:
               name: {{ if not (empty .Values.external_secrets.silo_env_existingSecret) }}{{ .Values.external_secrets.silo_env_existingSecret }}{{ else }}{{ .Release.Name }}-silo-secrets{{ end }}
               optional: false
           {{- end }}
-        {{- if .Values.extraEnv }}
+        {{- if or .Values.extraEnv .Values.observability.otel.enabled }}
         env:
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "beat-worker" "full" false)) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 10 }}
+          {{- end }}
         {{- end }}
 
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -96,9 +96,12 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.live_env_existingSecret) }}{{ .Values.external_secrets.live_env_existingSecret }}{{ else }}{{ .Release.Name }}-live-secrets{{ end }}
               optional: false
-        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) .Values.observability.otel.enabled }}
         env:
           {{- with (include "plane.s3CANodeEnvVars" .) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "live")) }}
 {{ . | indent 10 }}
           {{- end }}
           {{- if .Values.extraEnv }}

--- a/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
@@ -47,9 +47,14 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.app_env_existingSecret) }}{{ .Values.external_secrets.app_env_existingSecret }}{{ else }}{{ .Release.Name }}-app-secrets{{ end }}
               optional: false
-        {{- if .Values.extraEnv }}
+        {{- if or .Values.extraEnv .Values.observability.otel.enabled }}
         env:
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "outbox-poller" "full" false)) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 10 }}
+          {{- end }}
         {{- end }}
 
       serviceAccount: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
@@ -88,9 +88,12 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.opensearch_existingSecret) }}{{ .Values.external_secrets.opensearch_existingSecret }}{{ else }}{{ .Release.Name }}-opensearch-secrets{{ end }}
               optional: false
-        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) .Values.observability.otel.enabled }}
         env:
           {{- with (include "plane.s3CAEnvVars" .) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "pi-api")) }}
 {{ . | indent 10 }}
           {{- end }}
           {{- if .Values.extraEnv }}

--- a/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
@@ -64,9 +64,12 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.opensearch_existingSecret) }}{{ .Values.external_secrets.opensearch_existingSecret }}{{ else }}{{ .Release.Name }}-opensearch-secrets{{ end }}
               optional: false
-        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) .Values.observability.otel.enabled }}
         env:
           {{- with (include "plane.s3CAEnvVars" .) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "pi-beat")) }}
 {{ . | indent 10 }}
           {{- end }}
           {{- if .Values.extraEnv }}

--- a/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
@@ -64,9 +64,12 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.opensearch_existingSecret) }}{{ .Values.external_secrets.opensearch_existingSecret }}{{ else }}{{ .Release.Name }}-opensearch-secrets{{ end }}
               optional: false
-        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) .Values.observability.otel.enabled }}
         env:
           {{- with (include "plane.s3CAEnvVars" .) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "pi-worker")) }}
 {{ . | indent 10 }}
           {{- end }}
           {{- if .Values.extraEnv }}

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -122,9 +122,12 @@ spec:
           - secretRef:
               name: {{ if not (empty .Values.external_secrets.doc_store_existingSecret) }}{{ .Values.external_secrets.doc_store_existingSecret }}{{ else }}{{ .Release.Name }}-doc-store-secrets{{ end }}
               optional: false
-        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) .Values.observability.otel.enabled }}
         env:
           {{- with (include "plane.s3CANodeEnvVars" .) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "silo")) }}
 {{ . | indent 10 }}
           {{- end }}
           {{- if .Values.extraEnv }}

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -58,9 +58,14 @@ spec:
           limits:
             memory: {{ .Values.services.space.memoryLimit  | default "1000Mi" | quote }}
             cpu: {{ .Values.services.space.cpuLimit | default "500m" | quote}}
-        {{- if .Values.extraEnv }}
+        {{- if or .Values.extraEnv .Values.observability.otel.enabled }}
         env:
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "space")) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 10 }}
+          {{- end }}
         {{- end }}
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -70,9 +70,12 @@ spec:
               optional: false
           {{- end }}
 
-        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) }}
+        {{- if or .Values.extraEnv (include "plane.s3CAEnabled" .) .Values.observability.otel.enabled }}
         env:
           {{- with (include "plane.s3CAEnvVars" .) }}
+{{ . | indent 10 }}
+          {{- end }}
+          {{- with (include "plane.otelServiceEnv" (dict "context" $ "service" "worker" "full" false)) }}
 {{ . | indent 10 }}
           {{- end }}
           {{- if .Values.extraEnv }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -639,3 +639,47 @@ extraEnv: []
   #   value: "http://proxy.example.com:8080"
   # - name: NO_PROXY
   #   value: "localhost,127.0.0.1,.example.com"
+
+# OpenTelemetry APM for the Django backend (api, worker, beat-worker,
+# automation-consumer, outbox-poller, migrator). Off by default — when
+# enabled, OTEL env vars are injected into the backend app-vars ConfigMap.
+# Point `endpoint` at any OTLP collector. See docs/otel-api-observability
+# in the plane-ee repo for the full guide.
+observability:
+  otel:
+    enabled: false
+    # Service name reported to your APM backend.
+    serviceName: plane-api
+    # OTLP receiver, e.g. http://otel-collector.<ns>.svc.cluster.local:4317
+    endpoint: ""
+    # grpc | http/protobuf
+    protocol: grpc
+    # Standard OTEL head sampler. Set tracesSamplerArg to "1.0" to capture every request.
+    tracesSampler: parentbased_traceidratio
+    tracesSamplerArg: "0.1"
+    # Extra resource attrs, e.g. "deployment.environment=prod,service.version=v2.6.1"
+    resourceAttributes: ""
+    # Auth headers for SaaS backends (rendered into app-secrets), e.g. "Authorization=Bearer%20<token>"
+    headers: ""
+    # Bundled in-cluster OpenTelemetry Collector. When enabled, the chart deploys
+    # a collector Deployment/Service/ConfigMap and — if `endpoint` above is empty —
+    # the backend auto-targets it. Leave disabled to export to an external
+    # collector (Datadog Agent, Grafana Cloud, an existing cluster collector).
+    collector:
+      enabled: false
+      image: otel/opentelemetry-collector-contrib:0.115.1
+      pullPolicy: IfNotPresent
+      replicas: 1
+      memoryRequest: 128Mi
+      cpuRequest: 100m
+      memoryLimit: 512Mi
+      cpuLimit: 500m
+      # Optional full collector config override (YAML string). When empty, a
+      # default OTLP-in → `debug`-out pipeline is used (good for verifying spans;
+      # replace `debug` with a real exporter for production).
+      config: ""
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      labels: {}
+      annotations: {}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -640,27 +640,45 @@ extraEnv: []
   # - name: NO_PROXY
   #   value: "localhost,127.0.0.1,.example.com"
 
-# OpenTelemetry APM for the Django backend (api, worker, beat-worker,
-# automation-consumer, outbox-poller, migrator). Off by default — when
-# enabled, OTEL env vars are injected into the backend app-vars ConfigMap.
-# Point `endpoint` at any OTLP collector. See docs/otel-api-observability
-# in the plane-ee repo for the full guide.
+# OpenTelemetry APM. Off by default — when enabled, OTEL env vars are injected
+# into every instrumented workload: the Django backend (api, worker, beat-worker,
+# automation-consumer, outbox-poller, migrator) via the app-vars ConfigMap, and
+# the Node services (silo, live), the SSR frontend (space) and Plane Intelligence
+# (pi-api, pi-worker, pi-beat) via inline env. Each workload reports its own
+# OTEL_SERVICE_NAME. Point `endpoint` at any OTLP collector. See
+# docs/otel-api-observability in the plane-ee repo for the full guide.
 observability:
   otel:
     enabled: false
-    # Service name reported to your APM backend.
+    # Service name reported to your APM backend for the api workload. The other
+    # workloads report their own name (silo, live, space, worker, pi-api, …).
     serviceName: plane-api
     # OTLP receiver, e.g. http://otel-collector.<ns>.svc.cluster.local:4317
     endpoint: ""
     # grpc | http/protobuf
     protocol: grpc
-    # Standard OTEL head sampler. Set tracesSamplerArg to "1.0" to capture every request.
+    # Standard OTEL head sampler. Set tracesSampler=always_on (or tracesSamplerArg
+    # to "1.0") to capture every request — recommended for test/load/debug envs.
     tracesSampler: parentbased_traceidratio
     tracesSamplerArg: "0.1"
-    # Extra resource attrs, e.g. "deployment.environment=prod,service.version=v2.6.1"
+    # Extra resource attrs, e.g. "deployment.environment.name=prod,service.version=v2.6.3"
     resourceAttributes: ""
-    # Auth headers for SaaS backends (rendered into app-secrets), e.g. "Authorization=Bearer%20<token>"
+    # Auth headers for SaaS backends (rendered into app-secrets for the Django
+    # backend, inline for the Node/pi workloads), e.g. "Authorization=Bearer%20<token>"
     headers: ""
+    # Emit spans to the container console in addition to the OTLP exporter (debug aid).
+    debugConsole: false
+    # Browser/client tracing for the web/admin/space frontends. These keys are
+    # served to browsers by the API (via its public instance config) and are only
+    # read by the API workload, so they are injected into app-vars alongside the
+    # backend OTEL_* keys. Turn on with frontend.enabled=true.
+    frontend:
+      enabled: false
+      # OTLP endpoint the browser posts spans to (must be reachable cross-origin
+      # from the browser), e.g. https://telemetry.example.com
+      endpoint: ""
+      # Optional auth headers for the browser exporter.
+      headers: ""
     # Bundled in-cluster OpenTelemetry Collector. When enabled, the chart deploys
     # a collector Deployment/Service/ConfigMap and — if `endpoint` above is empty —
     # the backend auto-targets it. Leave disabled to export to an external


### PR DESCRIPTION
## Summary

Adds first-class **OpenTelemetry APM** support to the `plane-enterprise` chart so self-hosters can enable backend tracing/metrics/log-correlation via values instead of hand-rolled `extraEnv`. Pairs with the `feat/otel-api-observability` work in `plane-ee` (which adds the `configure_otel()` bootstrap to the Django backend). Chart version bumped **2.5.0 → 2.5.1**.

## What changed

- **`values.yaml`** — new `observability.otel` block (off by default) with a nested `collector` sub-block for an optional bundled OTLP collector.
- **`templates/config-secrets/app-env.yaml`** — when `observability.otel.enabled`, injects `OTEL_*` into the backend `-app-vars` ConfigMap. Scoped to the six workloads that `envFrom` it (api, worker, beat-worker, automation-consumer, outbox-poller, migrator) — no frontend pods touched. Auth headers (if any) go into `-app-secrets`. When `endpoint` is blank **and** the bundled collector is enabled, the backend auto-targets the in-cluster collector Service.
- **`templates/observability/otel-collector.yaml`** — bundled collector (ConfigMap/Service/Deployment), gated on `observability.otel.collector.enabled`, with an overridable `config` defaulting to an `OTLP-in → debug-out` pipeline.

## How to enable

```yaml
observability:
  otel:
    enabled: true
    serviceName: plane-api
    endpoint: ""          # blank → auto-targets the bundled collector below
    tracesSamplerArg: "1.0"
    collector:
      enabled: true       # deploy the in-cluster OTLP collector
```

Point at an external collector instead by setting `observability.otel.endpoint` and leaving `collector.enabled: false`.

## Testing

Deployed to a live EKS cluster (namespace `gpotel`, isolated DB, backend image built from `feat/otel-api-observability`) and drove real traffic.

**Render gating — `helm template` + `helm lint`:**

| Scenario | Result |
|---|---|
| `helm lint` | `1 chart(s) linted, 0 chart(s) failed` |
| OTEL disabled (chart defaults) | 0 collector resources, 0 `OTEL_*` env |
| OTEL on + collector off | no collector resources; `OTEL_EXPORTER_OTLP_ENDPOINT: ""` (external-collector mode) |
| OTEL on + collector on | collector deployed; backend endpoint auto-wired to `http://<release>-otel-collector.<ns>.svc.cluster.local:4317` |

**Live spans received by the bundled collector** (`kubectl logs deploy/plane-gpotel-otel-collector`):

```
# HTTP server spans (DjangoInstrumentor) from browsing the app
Name: GET   -> http.method: Str(GET)   -> http.status_code: Int(200)
Name: POST  -> http.method: Str(POST)

# Celery spans — apply_async (enqueue) linked to run (execution) via
# traceparent propagated through RabbitMQ
celery.action: Str(apply_async)  celery.task_name: ...batched_search_update_task...
celery.action: Str(run)          celery.task_name: ...batched_search_update_task...

# Postgres child spans nested under the above
Name: SELECT   -> db.system: Str(postgresql)

# all tagged
service.name: Str(plane-api)
```

**Log ↔ trace correlation:** worker/Celery logs carry populated `trace_id` (32-hex), confirming the `TraceContextFilter` path. _(Follow-up, app-side not chart-side: the API request **access log** currently emits empty `trace_id`/`span_id` because it logs outside the active span context — tracked against the `plane-ee` branch, not this chart.)_

## Notes

- Bundled collector defaults to the `debug` exporter (verification only) — set `observability.otel.collector.config` to export to a real backend (Tempo/Datadog/Honeycomb), or disable it and use `observability.otel.endpoint`.
- Collector image pinned to `otel/opentelemetry-collector-contrib:0.115.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry observability integration, including configurable OTLP exporter settings (endpoint, protocol, sampling), optional resource attributes and headers, and optional debug output.
  * Injected OpenTelemetry environment variables across multiple workloads, and added frontend/browser tracing options.
  * Added an optional bundled in-cluster OpenTelemetry Collector with a default OTLP-to-debug pipeline.

* **Chores**
  * Bumped the Helm chart version from **2.7.0** to **2.8.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->