### PR TITLE
feat: add opt-in gitops mode for deterministic rendering (plane-enterprise + plane-ce)

### DIFF
--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -39,7 +39,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-admin

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -39,7 +39,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -16,7 +16,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-beat-worker

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -39,7 +39,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-live

--- a/charts/plane-ce/templates/workloads/migrator.job.yaml
+++ b/charts/plane-ce/templates/workloads/migrator.job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ .Release.Name }}-api-migrate-{{ .Release.Revision }}
+  name: {{ .Release.Name }}-api-migrate-{{ if $.Values.gitops.enabled }}{{ .Values.planeVersion | replace "." "-" | replace "+" "-" | lower }}{{ else }}{{ .Release.Revision }}{{ end }}
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
 spec:
   backoffLimit: 3
@@ -13,7 +13,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api-migrate

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -87,7 +87,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ .Release.Name }}-minio-bucket-{{ .Release.Revision }}
+  name: {{ .Release.Name }}-minio-bucket-{{ if $.Values.gitops.enabled }}{{ .Values.planeVersion | replace "." "-" | replace "+" "-" | lower }}{{ else }}{{ .Release.Revision }}{{ end }}
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.minio) }}
 spec:
   backoffLimit: 6

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -39,7 +39,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-space

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -39,7 +39,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-web

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -16,7 +16,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-worker

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -1,5 +1,13 @@
 planeVersion: v1.2.0
 
+# GitOps mode: render deterministically for declarative tools (Argo CD / Flux). When true,
+# the per-render `timestamp` rollout annotation is omitted and migration Job names are keyed
+# to `planeVersion` instead of `.Release.Revision`, so repeated renders of an unchanged
+# release are byte-identical (no perpetual drift, no immutable-Job patch errors). Default
+# false preserves the existing imperative `helm upgrade` behavior exactly.
+gitops:
+  enabled: false
+
 dockerRegistry:
   enabled: false
   host: "index.docker.io/v1/"

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -40,7 +40,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.admin }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -40,7 +40,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.api }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
@@ -17,7 +17,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-automation-consumer
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.automation_consumer }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -16,7 +16,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.beatworker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/email.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/email.deployment.yaml
@@ -47,7 +47,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-email-app
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:  
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.email_service }}
       containers:

--- a/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
@@ -37,7 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-iframely
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.iframely }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -40,7 +40,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.live }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/migrator.job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ .Release.Name }}-api-migrate-{{ now | date "20060102-150405" }}
+  name: {{ .Release.Name }}-api-migrate-{{ if $.Values.gitops.enabled }}{{ .Values.planeVersion | replace "." "-" | replace "+" "-" | lower }}{{ else }}{{ now | date "20060102-150405" }}{{ end }}
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.api) }}
 spec:
   backoffLimit: 3
@@ -13,7 +13,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.api }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -87,7 +87,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ .Release.Name }}-minio-bucket-{{ now | date "20060102-150405" }}
+  name: {{ .Release.Name }}-minio-bucket-{{ if $.Values.gitops.enabled }}{{ .Values.planeVersion | replace "." "-" | replace "+" "-" | lower }}{{ else }}{{ now | date "20060102-150405" }}{{ end }}
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.minio) }}
 spec:
   backoffLimit: 6

--- a/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
@@ -37,7 +37,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-monitor
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.monitor }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
@@ -17,7 +17,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-outbox-poller
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.outbox_poller }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
@@ -41,7 +41,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-api
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
@@ -17,7 +17,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-beat
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi_beat_worker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-migrator.job.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ .Release.Name }}-pi-api-migrate-{{ now | date "20060102-150405" }}
+  name: {{ .Release.Name }}-pi-api-migrate-{{ if $.Values.gitops.enabled }}{{ .Values.planeVersion | replace "." "-" | replace "+" "-" | lower }}{{ else }}{{ now | date "20060102-150405" }}{{ end }}
   labels:
     {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
@@ -15,7 +15,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-api-migrate
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
@@ -17,7 +17,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-worker
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi_worker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
@@ -41,7 +41,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-runner
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.runner }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -41,7 +41,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.silo }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -40,7 +40,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.space }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -40,7 +40,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.web }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -16,7 +16,9 @@ spec:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
         {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
+        {{- if not $.Values.gitops.enabled }}
         timestamp: {{ now | quote }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.worker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,5 +1,13 @@
 planeVersion: v2.6.3
 
+# GitOps mode: render deterministically for declarative tools (Argo CD / Flux). When true,
+# the per-render `timestamp` rollout annotation is omitted and migration Job names are keyed
+# to `planeVersion` instead of a wall-clock timestamp, so repeated renders of an unchanged
+# release are byte-identical (no perpetual drift, no immutable-Job patch errors). Default
+# false preserves the existing imperative `helm upgrade` behavior exactly.
+gitops:
+  enabled: false
+
 dockerRegistry:
   enabled: false
   registry: 'index.docker.io/v1/'


### PR DESCRIPTION
## Summary

Adds an opt-in `gitops.enabled` flag (default `false`) to **both** `plane-enterprise` and `plane-ce`, so the charts render **deterministically** for declarative GitOps tools (Argo CD, Flux) — without changing anything for existing `helm install` / `helm upgrade` users.

- `gitops.enabled: false` (default): renders **byte-for-byte identical** to today.
- `gitops.enabled: true`: omits the per-render `timestamp: {{ now | quote }}` pod annotation, and keys migration Job names to `.Values.planeVersion` (instead of a wall-clock timestamp in plane-enterprise / `.Release.Revision` in plane-ce).

## Why

Several workload templates inject `timestamp: {{ now | quote }}` into `spec.template.metadata.annotations`, and the migration Jobs derive `metadata.name` from a per-render value. Under a GitOps reconciler this is fatal:

1. **Never reaches `Synced`; rolls every pod on every reconcile** — each Deployment's pod template differs on each render.
2. **Fails the migration Job with `field is immutable`** — Argo CD tries to patch the existing Job, but `Job.spec.template` is immutable.

Reported in **#158** (closed "intentional; couldn't reproduce the migrator breakage") and **#206** (the exact immutable-Job failure), then worked around in **#207** by making the plane-enterprise Job name timestamp-*unique* — which avoids the immutable error but runs the migration on every sync and orphans a Job each time. This fixes the root cause while preserving the intended default.

## Design — non-breaking, opt-in

`now` forces a rollout on every `helm upgrade` — reasonable for imperative users, so it stays the default; only opted-in GitOps users change behavior:

| | `gitops.enabled: false` (default) | `gitops.enabled: true` |
|---|---|---|
| pod `timestamp` annotation | unchanged | omitted |
| migration Job name suffix | unchanged (`now` / `.Release.Revision`) | `planeVersion` |
| rollout on every upgrade | yes (unchanged) | only on real spec change |

Version-keyed Job names are deterministic per release, re-run cleanly on a version bump (new name → new Job; Argo CD prunes the old one), and never hit the immutable-Job patch. The charts already ship `reloader.stakater.com/auto` on some workloads — the deterministic, config-driven rollout mechanism — so GitOps users don't lose config-change rollouts by dropping the `now` annotation.

## Proof it doesn't change the default

`helm template` with default values is identical to the current chart (modulo the `now` values that already differ between any two renders), for both charts:

```
plane-enterprise:  diff(norm(upstream), norm(this-branch defaults))  ->  empty
plane-ce:          diff(norm(upstream), norm(this-branch defaults))  ->  empty
```

With `gitops.enabled=true`, repeated renders are identical and contain no `now`:

```
                  timestamp annotations      migrate Job name
plane-enterprise  default 10 -> gitops 0     ...-migrate-20260614-... -> ...-migrate-v2-6-2
plane-ce          default  8 -> gitops 0     ...-migrate-1            -> ...-migrate-v1-2-0
```

## Scope

`charts/plane-enterprise` and `charts/plane-ce` — the `timestamp` annotation in their workload templates, version-keyed migration Job names, and the `gitops.enabled` values flag. No default-behavior change in either chart.

Relates to #158, #206, #207.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `gitops` configuration option to support deterministic Helm rendering across Plane charts.

* **Configuration**
  * New `gitops` block (default: disabled). When enabled, per-workload `timestamp` pod annotation values are omitted, and migration job naming switches to a version-based scheme (instead of timestamp/revision-based naming) for more repeatable deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->