### PR TITLE
[INFRA-413] fix(plane-enterprise): decouple ingress controller type from class name

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.6.2
+version: 2.6.3
 appVersion: "2.6.3"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 3.5.4
+version: 3.5.5
 appVersion: "3.1.4"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -27,24 +27,44 @@ If you plan to use Traefik as your ingress controller, install it before deployi
 
 ## Migrating the Ingress Controller
 
-The chart selects between two ingress templates based on `ingress.ingressClass`:
+The chart renders one of two ingress templates. **Which one** is chosen by the
+*controller type* — kept separate from the *class name* so atypical class names
+(e.g. `nginx-new`, or a Traefik-named alias served by a standard controller) work
+without changing template selection.
 
-| `ingressClass` value           | Template rendered                | Resource kind                      |
-| ------------------------------ | -------------------------------- | ---------------------------------- |
-| `traefik` (or starts with it)  | `templates/ingress-traefik.yaml` | `traefik.io/v1alpha1 IngressRoute` |
-| Any other value (e.g. `nginx`) | `templates/ingress.yaml`         | `networking.k8s.io/v1 Ingress`     |
+`ingress.controller` selects the resource kind:
 
-The default value is `"traefik"`. If you are switching to a standard ingress controller such as nginx, follow the migration steps below.
+| `ingress.controller` value           | Template rendered                | Resource kind                      |
+| ------------------------------------- | -------------------------------- | ---------------------------------- |
+| `traefik`                             | `templates/ingress-traefik.yaml` | `traefik.io/v1alpha1 IngressRoute` |
+| Any other value (`nginx`, `f5`, ...)  | `templates/ingress.yaml`         | `networking.k8s.io/v1 Ingress`     |
+
+> The standard `Ingress` path covers **any** standard Kubernetes ingress controller —
+> ingress-nginx, F5 NGINX, HAProxy, etc. The value is just a selector; it is not
+> written anywhere. The actual class name comes from `ingress.ingressClass`
+> (`spec.ingressClassName`), which can be any string your controller exposes.
+
+If `ingress.controller` is left empty, the controller is **auto-detected** from
+`ingress.ingressClass` for backward compatibility: a value starting with `traefik`
+selects Traefik, anything else selects the standard `Ingress`. Set
+`ingress.controller` explicitly to override this — for example, to serve a standard
+`Ingress` whose `ingressClassName` happens to start with `traefik`, or to use a
+non-`nginx` class name like `nginx-new` (which previously was silently dropped).
+
+The default is a Traefik `IngressRoute` (`ingressClass: traefik`, controller
+auto-detected). If you are switching to a standard ingress controller, follow the
+migration steps below.
 
 ### Switching from Traefik to a standard Ingress controller (e.g. nginx)
 
 1. **Install your target ingress controller** if it is not already running.
 
-2. **Update `ingress.ingressClass`** in your `values.yaml`:
+2. **Set `ingress.controller` and `ingress.ingressClass`** in your `values.yaml`:
 
    ```yaml
    ingress:
-     ingressClass: "nginx"   # or whichever class your controller exposes
+     controller: "nginx"      # selects the standard Ingress template (any value but "traefik")
+     ingressClass: "nginx"    # spec.ingressClassName — whichever class your controller exposes (e.g. "nginx-new")
    ```
 
 3. **Run `helm upgrade`**:
@@ -69,11 +89,12 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
 
 1. **Install Traefik** with CRD support enabled (see [Installing Traefik Ingress Controller](#installing-traefik-ingress-controller-optional) above).
 
-2. **Update `ingress.ingressClass`**:
+2. **Set `ingress.controller`**:
 
    ```yaml
    ingress:
-     ingressClass: "traefik"
+     controller: "traefik"
+     ingressClass: "traefik"   # unused by the IngressRoute, kept for clarity
    ```
 
 3. **Run `helm upgrade`**. The old `Ingress` resource is orphaned — delete it:
@@ -87,9 +108,10 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
 | Value                                 | Default    | Effect                                                                                    |
 | ------------------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
 | `ingress.enabled`                     | `true`     | Master switch — set to `false` to render neither template.                                |
-| `ingress.ingressClass`                | `traefik`  | Selects which template is active (see table above).                                       |
+| `ingress.controller`                  | `''`       | Selects the resource kind: `traefik` → IngressRoute, anything else → standard `Ingress`. Empty = auto-detect from `ingressClass`. |
+| `ingress.ingressClass`                | `traefik`  | Free-form `spec.ingressClassName` on the standard `Ingress`. Also drives auto-detection when `controller` is empty. Unused by Traefik. |
 | `ingress.traefik.maxRequestBodyBytes` | `20971520` | Max request body size for Traefik's buffering middleware. Ignored when not using Traefik. |
-| `ingress.ingress_annotations`         | `{}`       | Standard `Ingress` annotations. Ignored when `ingressClass` starts with `traefik`.       |
+| `ingress.ingress_annotations`         | `{}`       | Standard `Ingress` annotations (e.g. cert-manager). Rendered only on the standard `Ingress`; ignored when `controller` resolves to `traefik`. |
 
 ## Installing Plane
 
@@ -158,6 +180,7 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
      - `planeVersion: v2.6.3 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
+     - `ingress.controller: <traefik | nginx | ... — leave empty to auto-detect from ingressClass>`
      - `ingress.ingressClass: <traefik or any other ingress class configured in your cluster>`
      - `env.storageClass: <default storage class configured in your cluster>`
 
@@ -760,7 +783,8 @@ Note: When the email service is enabled, the cert-issuer will be automatically c
 | ingress.enabled             |                           true                            |          | Ingress setup in kubernetes is a common practice to expose application to the intended audience. Set it to `false` if you are using external ingress providers like `Cloudflare`                                                                                                                                                                                                                                          |
 | ingress.minioHost           |                                                           |          | Based on above configuration, if you want to expose the `minio` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                       |
 | ingress.rabbitmqHost        |                                                           |          | Based on above configuration, if you want to expose the `rabbitmq` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                    |
-| ingress.ingressClass        |                           nginx                           |   Yes    | Kubernetes cluster setup comes with various options of `ingressClass`. Based on your setup, set this value to the right one (eg. nginx, traefik, etc). Leave it to default in case you are using external ingress provider.                                                                                                                                                                                               |
+| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress`. Leave empty to auto-detect from `ingressClass`. Set explicitly for atypical class names (e.g. `nginx-new`) or a Traefik-named alias served by a standard controller.                                                                                          |
+| ingress.ingressClass        |                          traefik                          |   Yes    | Free-form class name written to the standard `Ingress` `spec.ingressClassName` (eg. nginx, traefik, nginx-new, etc). When `controller` is empty it also drives auto-detection. Unused by the Traefik `IngressRoute`.                                                                                                                                                                                                       |
 | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |          | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required.                                                                                                                                                                                                                                                   |
 | ssl.createIssuer            |                           false                           |          | Kubernets cluster setup supports creating `issuer` type resource. After deployment, this is step towards creating secure access to the ingress url. Issuer is required for you generate SSL certifiate. Kubernetes can be configured to use any of the certificate authority to generate SSL (depending on CertManager configuration). Set it to `true` to create the issuer. Applicable only when `ingress.enabled=true` |
 | ssl.issuer                  |                           http                            |          | CertManager configuration allows user to create issuers using `http` or any of the other DNS Providers like `cloudflare`, `digitalocean`, etc. As of now Plane supports `http`, `cloudflare`, `digitalocean`                                                                                                                                                                                                              |

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -29,8 +29,7 @@ If you plan to use Traefik as your ingress controller, install it before deployi
 
 The chart renders one of two ingress templates. **Which one** is chosen by the
 *controller type* — kept separate from the *class name* so atypical class names
-(e.g. `nginx-new`, or a Traefik-named alias served by a standard controller) work
-without changing template selection.
+(e.g. `nginx-new`) work without changing template selection.
 
 `ingress.controller` selects the resource kind:
 
@@ -47,9 +46,8 @@ without changing template selection.
 If `ingress.controller` is left empty, the controller is **auto-detected** from
 `ingress.ingressClass` for backward compatibility: a value starting with `traefik`
 selects Traefik, anything else selects the standard `Ingress`. Set
-`ingress.controller` explicitly to override this — for example, to serve a standard
-`Ingress` whose `ingressClassName` happens to start with `traefik`, or to use a
-non-`nginx` class name like `nginx-new` (which previously was silently dropped).
+`ingress.controller` explicitly to use a non-`nginx` class name like `nginx-new`
+(which previously was silently dropped).
 
 The default is a Traefik `IngressRoute` (`ingressClass: traefik`, controller
 auto-detected). If you are switching to a standard ingress controller, follow the
@@ -783,7 +781,7 @@ Note: When the email service is enabled, the cert-issuer will be automatically c
 | ingress.enabled             |                           true                            |          | Ingress setup in kubernetes is a common practice to expose application to the intended audience. Set it to `false` if you are using external ingress providers like `Cloudflare`                                                                                                                                                                                                                                          |
 | ingress.minioHost           |                                                           |          | Based on above configuration, if you want to expose the `minio` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                       |
 | ingress.rabbitmqHost        |                                                           |          | Based on above configuration, if you want to expose the `rabbitmq` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                    |
-| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress`. Leave empty to auto-detect from `ingressClass`. Set explicitly for atypical class names (e.g. `nginx-new`) or a Traefik-named alias served by a standard controller.                                                                                          |
+| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress`. Leave empty to auto-detect from `ingressClass`. Set explicitly for atypical class names (e.g. `nginx-new`).                                                                                          |
 | ingress.ingressClass        |                          traefik                          |   Yes    | Free-form class name written to the standard `Ingress` `spec.ingressClassName` (eg. nginx, traefik, nginx-new, etc). When `controller` is empty it also drives auto-detection. Unused by the Traefik `IngressRoute`.                                                                                                                                                                                                       |
 | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |          | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required.                                                                                                                                                                                                                                                   |
 | ssl.createIssuer            |                           false                           |          | Kubernets cluster setup supports creating `issuer` type resource. After deployment, this is step towards creating secure access to the ingress url. Issuer is required for you generate SSL certifiate. Kubernetes can be configured to use any of the certificate authority to generate SSL (depending on CertManager configuration). Set it to `true` to create the issuer. Applicable only when `ingress.enabled=true` |

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -28,8 +28,9 @@ If you plan to use Traefik as your ingress controller, install it before deployi
 ## Migrating the Ingress Controller
 
 The chart renders one of three ingress templates. **Which one** is chosen by the
-*controller type* — kept separate from the *class name*, so atypical class names
-(e.g. `nginx-new`) work without changing template selection.
+*controller type* — kept separate from the *class name*, so a class name your
+controller happens to use (e.g. `nginx-new`, `alb`) no longer has to double as the
+template selector.
 
 `ingress.controller` selects the resource kind:
 
@@ -48,15 +49,33 @@ The chart renders one of three ingress templates. **Which one** is chosen by the
 > OpenShift equivalent; HAProxy Routes cannot cap request bodies. Enforce upload
 > limits in the application or at a WAF/CDN in front of the router.
 
-If `ingress.controller` is left empty, the controller is **inferred** from
-`ingress.ingressClass` for backward compatibility: a value starting with `traefik`
-selects Traefik, exactly `openshift` selects Routes, anything else selects the
-standard `Ingress`. Set `ingress.controller` explicitly to use a non-`nginx` class
-name like `nginx-new` (which previously rendered nothing at all, silently).
+#### If you leave `ingress.controller` empty
 
-The default is a Traefik `IngressRoute` (`ingressClass: traefik`, controller
-auto-detected). If you are switching to a standard ingress controller, follow the
-migration steps below.
+The selection falls back to `ingress.ingressClass`, and is **exactly** what it was
+before this value existed:
+
+| `ingressClass` with no `controller`     | Renders                      |
+| --------------------------------------- | ---------------------------- |
+| `traefik`, or anything starting with it | Traefik `IngressRoute`       |
+| `openshift`                             | OpenShift `Route`s           |
+| `nginx`                                 | Standard `Ingress`           |
+| **anything else**                       | **nothing at all, silently** |
+
+> ⚠️ **`alb`, `contour`, `istio`, `gce`, `nginx-new`, `openshift-default`, a custom
+> `IngressClass` name, an empty string — all render no ingress** while
+> `ingress.controller` is empty. `helm install` succeeds and nothing is reachable.
+> **Set `ingress.controller`** (to `nginx`, or any label you like) to get a standard
+> `Ingress` carrying your class name.
+
+This no-op is kept on purpose rather than widened: an operator on such a class today
+gets no ingress from the chart and will have their own in place, so making the
+fallback render one would create a second, conflicting `<release>-ingress` on
+upgrade — or fail the upgrade outright if theirs shares that name. Opting in via
+`ingress.controller` keeps upgrades inert until you ask for the change.
+
+The default is a Traefik `IngressRoute` (`ingressClass: traefik`, no `controller`).
+If you are switching to a standard ingress controller, follow the migration steps
+below.
 
 ### Switching from Traefik to a standard Ingress controller (e.g. nginx)
 
@@ -111,8 +130,8 @@ migration steps below.
 | Value                                 | Default    | Effect                                                                                    |
 | ------------------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
 | `ingress.enabled`                     | `true`     | Master switch — set to `false` to render no ingress at all.                               |
-| `ingress.controller`                  | `''`       | Selects the resource kind: `traefik` → IngressRoute, `openshift` → Routes, anything else → standard `Ingress`. Empty = infer from `ingressClass`. |
-| `ingress.ingressClass`                | `traefik`  | Free-form `spec.ingressClassName` on the standard `Ingress`. Also drives the inference when `controller` is empty. Unused by Traefik and OpenShift. |
+| `ingress.controller`                  | `''`       | Selects the resource kind: `traefik` → IngressRoute, `openshift` → Routes, anything else → standard `Ingress` with your class name. Empty = legacy selection from `ingressClass`, where only `nginx`/`openshift`/`traefik*` render anything. |
+| `ingress.ingressClass`                | `traefik`  | Free-form `spec.ingressClassName` on the standard `Ingress`. Also drives the legacy selection while `controller` is empty. Unused by Traefik and OpenShift. |
 | `ingress.traefik.maxRequestBodyBytes` | `20971520` | Max request body size for Traefik's buffering middleware. Ignored when not using Traefik. |
 | `ingress.traefik.entryPoints`         | `[]`       | Traefik entrypoints for the `IngressRoute`. Empty means derive from your SSL settings — see below. Ignored when not using Traefik. |
 | `ingress.ingress_annotations`         | `{}`       | Standard `Ingress` annotations (e.g. cert-manager). Rendered only on the standard `Ingress`; the `openshift` path uses `ingress.openshift.route_annotations` and Traefik ignores them. |
@@ -390,7 +409,7 @@ ingress:
      - `planeVersion: v3.1.4 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
-     - `ingress.controller: <traefik | openshift | nginx | ... — leave empty to infer from ingressClass>`
+     - `ingress.controller: <traefik | openshift | nginx | ... — required unless ingressClass is exactly nginx/openshift/traefik*>`
      - `ingress.ingressClass: <traefik or any other ingress class configured in your cluster>`
      - `env.storageClass: <default storage class configured in your cluster>`
 
@@ -1161,8 +1180,8 @@ Note: When the email service is enabled, the cert-issuer will be automatically c
 | ingress.enabled             |                           true                            |          | Ingress setup in kubernetes is a common practice to expose application to the intended audience. Set it to `false` if you are using external ingress providers like `Cloudflare`                                                                                                                                                                                                                                          |
 | ingress.minioHost           |                                                           |          | Based on above configuration, if you want to expose the `minio` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                       |
 | ingress.rabbitmqHost        |                                                           |          | Based on above configuration, if you want to expose the `rabbitmq` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                    |
-| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; `openshift` renders one `route.openshift.io/v1 Route` per path; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress`. Leave empty to infer it from `ingressClass`. Set explicitly for atypical class names (e.g. `nginx-new`).                                                                                       |
-| ingress.ingressClass        |                          traefik                          |   Yes    | Free-form class name written to the standard `Ingress` `spec.ingressClassName` (eg. nginx, traefik, nginx-new, etc). When `controller` is empty it also drives the inference. Unused by the Traefik `IngressRoute` and by OpenShift `Route`s.                                                                                                                                                                              |
+| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; `openshift` renders one `route.openshift.io/v1 Route` per path; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress` using `ingressClass` verbatim. **Required when your class is not exactly `nginx`, `openshift` or `traefik*`** — left empty, any other class renders no ingress at all. |
+| ingress.ingressClass        |                          traefik                          |   Yes    | Free-form class name written to the standard `Ingress` `spec.ingressClassName` (eg. nginx, traefik, nginx-new, etc). While `controller` is empty it also selects the template, and only `nginx`, `openshift` and `traefik*` are recognised. Unused by the Traefik `IngressRoute` and by OpenShift `Route`s. |
 | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |          | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required.                                                                                                                                                                                                                                                   |
 | ingress.traefik.entryPoints |                           `[]`                            |          | Traefik entrypoints the `IngressRoute` binds to. Leave empty to derive them from your `ssl.*` settings (`websecure` when TLS is configured, otherwise `web`). Set explicitly only if your Traefik renamed the default entrypoints, e.g. `['websecure','web']`. Ignored unless the controller resolves to `traefik` |
 | ingress.traefik.maxRequestBodyBytes |                    20971520                     |          | Max request body size in bytes for Traefik's buffering middleware (upload size limit). Ignored unless the controller resolves to `traefik` |

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -123,7 +123,7 @@ ingress:
 Renders one `Ingress` with `ingressClassName: nginx`. The class must be exactly
 `nginx` for this to work without `controller`.
 
-**3. OpenShift `Route`s**
+**3. OpenShift Route's**
 
 ```yaml
 ingress:
@@ -182,7 +182,7 @@ ingress:
 Renders `IngressRoute` + `Middleware`. Useful when your platform's naming convention
 does not allow a class called `traefik`.
 
-**7. OpenShift `Route`s with a class name that is not `openshift`**
+**7. OpenShift Route's with a class name that is not `openshift`**
 
 ```yaml
 ingress:

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -27,35 +27,50 @@ If you plan to use Traefik as your ingress controller, install it before deployi
 
 ## Migrating the Ingress Controller
 
-The chart selects between three ingress templates based on `ingress.ingressClass`:
+The chart renders one of three ingress templates. **Which one** is chosen by the
+*controller type* — kept separate from the *class name*, so atypical class names
+(e.g. `nginx-new`, or a Traefik-named alias served by a standard controller) work
+without changing template selection.
 
-| `ingressClass` value          | Template rendered                  | Resource kind                                |
-| ----------------------------- | ---------------------------------- | -------------------------------------------- |
-| `traefik` (or starts with it) | `templates/ingress-traefik.yaml`   | `traefik.io/v1alpha1 IngressRoute`           |
-| `openshift`                   | `templates/ingress-openshift.yaml` | `route.openshift.io/v1 Route` (one per path) |
-| `nginx`                       | `templates/ingress.yaml`           | `networking.k8s.io/v1 Ingress`               |
+`ingress.controller` selects the resource kind:
 
-> **Any other value renders no ingress at all**, silently. `templates/ingress.yaml` is
-> gated on `ingressClass` being exactly `nginx`, so `alb`, `haproxy`, `contour`,
-> `openshift-default` or a custom IngressClass name produce a successful-looking
-> install with nothing reachable. Use one of the three values above, or create the
-> Ingress yourself.
+| `ingress.controller` value             | Template rendered                  | Resource kind                                |
+| -------------------------------------- | ---------------------------------- | -------------------------------------------- |
+| `traefik` (or starts with it)          | `templates/ingress-traefik.yaml`   | `traefik.io/v1alpha1 IngressRoute`           |
+| `openshift`                            | `templates/ingress-openshift.yaml` | `route.openshift.io/v1 Route` (one per path) |
+| Any other value (`nginx`, `f5`, ...)   | `templates/ingress.yaml`           | `networking.k8s.io/v1 Ingress`               |
+
+> The standard `Ingress` path covers **any** standard Kubernetes ingress controller —
+> ingress-nginx, F5 NGINX, HAProxy, ALB, Contour, etc. The value is just a selector;
+> it is not written anywhere. The actual class name comes from `ingress.ingressClass`
+> (`spec.ingressClassName`), which can be any string your controller exposes.
 
 > **No body-size limit on Routes.** `ingress.traefik.maxRequestBodyBytes` has no
 > OpenShift equivalent; HAProxy Routes cannot cap request bodies. Enforce upload
 > limits in the application or at a WAF/CDN in front of the router.
 
-The default value is `"traefik"`. If you are switching to a standard ingress controller such as nginx, follow the migration steps below.
+If `ingress.controller` is left empty, the controller is **inferred** from
+`ingress.ingressClass` for backward compatibility: a value starting with `traefik`
+selects Traefik, exactly `openshift` selects Routes, anything else selects the
+standard `Ingress`. Set `ingress.controller` explicitly to override that — for
+example to serve a standard `Ingress` whose `ingressClassName` happens to start
+with `traefik`, or to use a non-`nginx` class name like `nginx-new` (which
+previously rendered nothing at all, silently).
+
+The default is a Traefik `IngressRoute` (`ingressClass: traefik`, controller
+auto-detected). If you are switching to a standard ingress controller, follow the
+migration steps below.
 
 ### Switching from Traefik to a standard Ingress controller (e.g. nginx)
 
 1. **Install your target ingress controller** if it is not already running.
 
-2. **Update `ingress.ingressClass`** in your `values.yaml`:
+2. **Set `ingress.controller` and `ingress.ingressClass`** in your `values.yaml`:
 
    ```yaml
    ingress:
-     ingressClass: "nginx"   # supported: nginx | traefik* | openshift
+     controller: "nginx"      # selects the standard Ingress template (anything but traefik/openshift)
+     ingressClass: "nginx"    # spec.ingressClassName — whichever class your controller exposes (e.g. "nginx-new")
    ```
 
 3. **Run `helm upgrade`**:
@@ -80,11 +95,12 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
 
 1. **Install Traefik** with CRD support enabled (see [Installing Traefik Ingress Controller](#installing-traefik-ingress-controller-optional) above).
 
-2. **Update `ingress.ingressClass`**:
+2. **Set `ingress.controller`**:
 
    ```yaml
    ingress:
-     ingressClass: "traefik"
+     controller: "traefik"
+     ingressClass: "traefik"   # unused by the IngressRoute, kept for clarity
    ```
 
 3. **Run `helm upgrade`**. The old `Ingress` resource is orphaned — delete it:
@@ -97,11 +113,12 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
 
 | Value                                 | Default    | Effect                                                                                    |
 | ------------------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
-| `ingress.enabled`                     | `true`     | Master switch — set to `false` to render neither template.                                |
-| `ingress.ingressClass`                | `traefik`  | Selects which template is active (see table above).                                       |
+| `ingress.enabled`                     | `true`     | Master switch — set to `false` to render no ingress at all.                               |
+| `ingress.controller`                  | `''`       | Selects the resource kind: `traefik` → IngressRoute, `openshift` → Routes, anything else → standard `Ingress`. Empty = infer from `ingressClass`. |
+| `ingress.ingressClass`                | `traefik`  | Free-form `spec.ingressClassName` on the standard `Ingress`. Also drives the inference when `controller` is empty. Unused by Traefik and OpenShift. |
 | `ingress.traefik.maxRequestBodyBytes` | `20971520` | Max request body size for Traefik's buffering middleware. Ignored when not using Traefik. |
 | `ingress.traefik.entryPoints`         | `[]`       | Traefik entrypoints for the `IngressRoute`. Empty means derive from your SSL settings — see below. Ignored when not using Traefik. |
-| `ingress.ingress_annotations`         | `{}`       | Standard `Ingress` annotations. Only rendered when `ingressClass` is exactly `nginx`; the `openshift` Route path uses `ingress.openshift.route_annotations`. |
+| `ingress.ingress_annotations`         | `{}`       | Standard `Ingress` annotations (e.g. cert-manager). Rendered only on the standard `Ingress`; the `openshift` path uses `ingress.openshift.route_annotations` and Traefik ignores them. |
 | `ingress.openshift.timeout`           | `300s`     | HAProxy per-route timeout. The router default of 30s severs `/live/` WebSockets and `/pi/` streaming. |
 | `ingress.openshift.termination`       | `edge`     | Route TLS termination (`edge` or `reencrypt`; `passthrough` cannot do path routing).      |
 | `ingress.openshift.externalCertificate` | `''`     | Name of a TLS Secret for the router to serve instead of its wildcard cert. OpenShift 4.16+. |
@@ -264,7 +281,7 @@ If the redirection is present, every plain-HTTP request is answered with a
 permanent redirect *before* it reaches a route, so Option 1 cannot serve Plane on
 that cluster. Either drop the redirection, or use Option 2/3/4.
 
-#### A note on nginx (`ingress.ingressClass: nginx`)
+#### A note on the standard `Ingress` path (`ingress.controller: nginx`)
 
 The `ssl.*` settings above drive the standard `Ingress` path too — everything in
 the table applies except the **Entrypoint** column, which is Traefik-only:
@@ -276,6 +293,7 @@ the table applies except the **Entrypoint** column, which is Traefik-only:
 
 ```yaml
 ingress:
+  controller: nginx
   ingressClass: nginx
   ingress_annotations: { "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }
 ssl:
@@ -375,6 +393,7 @@ ingress:
      - `planeVersion: v3.1.4 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
+     - `ingress.controller: <traefik | openshift | nginx | ... — leave empty to infer from ingressClass>`
      - `ingress.ingressClass: <traefik or any other ingress class configured in your cluster>`
      - `env.storageClass: <default storage class configured in your cluster>`
 
@@ -1145,10 +1164,11 @@ Note: When the email service is enabled, the cert-issuer will be automatically c
 | ingress.enabled             |                           true                            |          | Ingress setup in kubernetes is a common practice to expose application to the intended audience. Set it to `false` if you are using external ingress providers like `Cloudflare`                                                                                                                                                                                                                                          |
 | ingress.minioHost           |                                                           |          | Based on above configuration, if you want to expose the `minio` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                       |
 | ingress.rabbitmqHost        |                                                           |          | Based on above configuration, if you want to expose the `rabbitmq` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                    |
-| ingress.ingressClass        |                           nginx                           |   Yes    | Kubernetes cluster setup comes with various options of `ingressClass`. Based on your setup, set this value to the right one (eg. nginx, traefik, etc). Leave it to default in case you are using external ingress provider.                                                                                                                                                                                               |
+| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; `openshift` renders one `route.openshift.io/v1 Route` per path; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress`. Leave empty to infer it from `ingressClass`. Set explicitly for atypical class names (e.g. `nginx-new`) or a Traefik-named alias served by a standard controller.                              |
+| ingress.ingressClass        |                          traefik                          |   Yes    | Free-form class name written to the standard `Ingress` `spec.ingressClassName` (eg. nginx, traefik, nginx-new, etc). When `controller` is empty it also drives the inference. Unused by the Traefik `IngressRoute` and by OpenShift `Route`s.                                                                                                                                                                              |
 | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |          | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required.                                                                                                                                                                                                                                                   |
-| ingress.traefik.entryPoints |                           `[]`                            |          | Traefik entrypoints the `IngressRoute` binds to. Leave empty to derive them from your `ssl.*` settings (`websecure` when TLS is configured, otherwise `web`). Set explicitly only if your Traefik renamed the default entrypoints, e.g. `['websecure','web']`. Ignored unless `ingressClass` starts with `traefik` |
-| ingress.traefik.maxRequestBodyBytes |                    20971520                     |          | Max request body size in bytes for Traefik's buffering middleware (upload size limit). Ignored unless `ingressClass` starts with `traefik` |
+| ingress.traefik.entryPoints |                           `[]`                            |          | Traefik entrypoints the `IngressRoute` binds to. Leave empty to derive them from your `ssl.*` settings (`websecure` when TLS is configured, otherwise `web`). Set explicitly only if your Traefik renamed the default entrypoints, e.g. `['websecure','web']`. Ignored unless the controller resolves to `traefik` |
+| ingress.traefik.maxRequestBodyBytes |                    20971520                     |          | Max request body size in bytes for Traefik's buffering middleware (upload size limit). Ignored unless the controller resolves to `traefik` |
 | ssl.createIssuer            |                           false                           |          | Kubernets cluster setup supports creating `issuer` type resource. After deployment, this is step towards creating secure access to the ingress url. Issuer is required for you generate SSL certifiate. Kubernetes can be configured to use any of the certificate authority to generate SSL (depending on CertManager configuration). Set it to `true` to create the issuer. Applicable only when `ingress.enabled=true` |
 | ssl.issuer                  |                           http                            |          | CertManager configuration allows user to create issuers using `http` or any of the other DNS Providers like `cloudflare`, `digitalocean`, etc. As of now Plane supports `http`, `cloudflare`, `digitalocean`                                                                                                                                                                                                              |
 | ssl.token                   |                                                           |          | To create issuers using DNS challenge, set the issuer api token of dns provider like cloudflare`or`digitalocean`(not required for http)                                                                                                                                                                                                                                                                                   |

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -27,23 +27,25 @@ If you plan to use Traefik as your ingress controller, install it before deployi
 
 ## Migrating the Ingress Controller
 
-The chart renders one of three ingress templates. **Which one** is chosen by the
-*controller type* — kept separate from the *class name*, so a class name your
-controller happens to use (e.g. `nginx-new`, `alb`) no longer has to double as the
-template selector.
+The chart renders one of three ingress templates — nginx, Traefik or OpenShift.
+**Which one** is chosen by the *controller type*, kept separate from the *class
+name*, so a class name your controller happens to use (e.g. `nginx-new`) no longer
+has to double as the template selector.
 
 `ingress.controller` selects the resource kind:
 
-| `ingress.controller` value             | Template rendered                  | Resource kind                                |
-| -------------------------------------- | ---------------------------------- | -------------------------------------------- |
-| `traefik` (or starts with it)          | `templates/ingress-traefik.yaml`   | `traefik.io/v1alpha1 IngressRoute`           |
-| `openshift`                            | `templates/ingress-openshift.yaml` | `route.openshift.io/v1 Route` (one per path) |
-| Any other value (`nginx`, `f5`, ...)   | `templates/ingress.yaml`           | `networking.k8s.io/v1 Ingress`               |
+| `ingress.controller` value        | Template rendered                  | Resource kind                                |
+| --------------------------------- | ---------------------------------- | -------------------------------------------- |
+| `traefik` (or starts with it)     | `templates/ingress-traefik.yaml`   | `traefik.io/v1alpha1 IngressRoute`           |
+| `openshift`                       | `templates/ingress-openshift.yaml` | `route.openshift.io/v1 Route` (one per path) |
+| `nginx`                           | `templates/ingress-nginx.yaml`     | `networking.k8s.io/v1 Ingress`               |
 
-> The standard `Ingress` path covers **any** standard Kubernetes ingress controller —
-> ingress-nginx, F5 NGINX, HAProxy, ALB, Contour, etc. The value is just a selector;
-> it is not written anywhere. The actual class name comes from `ingress.ingressClass`
-> (`spec.ingressClassName`), which can be any string your controller exposes.
+> **nginx, Traefik and OpenShift are the supported configurations.** The value is
+> only a selector and is never written into a manifest; the class name comes from
+> `ingress.ingressClass` (`spec.ingressClassName`), which can be any string your
+> controller exposes. Any `controller` value other than `traefik*`/`openshift`
+> renders the same standard `Ingress` as `nginx` — that is how a class name like
+> `nginx-new` is served — but only the three above are tested.
 
 > **No body-size limit on Routes.** `ingress.traefik.maxRequestBodyBytes` has no
 > OpenShift equivalent; HAProxy Routes cannot cap request bodies. Enforce upload
@@ -61,11 +63,12 @@ before this value existed:
 | `nginx`                                 | Standard `Ingress`           |
 | **anything else**                       | **nothing at all, silently** |
 
-> ⚠️ **`alb`, `contour`, `istio`, `gce`, `nginx-new`, `openshift-default`, a custom
-> `IngressClass` name, an empty string — all render no ingress** while
-> `ingress.controller` is empty. `helm install` succeeds and nothing is reachable.
-> **Set `ingress.controller`** (to `nginx`, or any label you like) to get a standard
-> `Ingress` carrying your class name.
+> ⚠️ **Any class other than `nginx`, `openshift` or `traefik*` renders no ingress**
+> while `ingress.controller` is empty — `nginx-new`, `openshift-default`, a custom
+> `IngressClass` name or an empty string included. `helm install` succeeds and
+> nothing is reachable. **Set `ingress.controller: nginx`** to get a standard
+> `Ingress` carrying your class name, or `ingress.enabled: false` if you manage the
+> ingress yourself.
 
 This no-op is kept on purpose rather than widened: an operator on such a class today
 gets no ingress from the chart and will have their own in place, so making the
@@ -149,11 +152,12 @@ unrecognised `ingressClass` to suppress it.
 
 #### Newly possible — set `ingress.controller`
 
-Each of these rendered **no ingress at all** before this change. `controller` picks
-the resource kind; `ingressClass` is then used verbatim as `spec.ingressClassName`.
+Each of these rendered **no ingress at all** before this change, because the class
+name was not one of the three the chart recognised. `controller` picks the resource
+kind; `ingressClass` is then used verbatim as `spec.ingressClassName`.
 
-**5. Standard `Ingress` with a class name that is not `nginx`** — e.g. F5 NGINX, or a
-second ingress-nginx install using a custom `IngressClass`
+**5. Standard `Ingress` with a class name that is not `nginx`** — e.g. a second
+ingress-nginx install, or an nginx build that exposes its own `IngressClass`
 
 ```yaml
 ingress:
@@ -166,38 +170,7 @@ ingress:
 
 Renders one `Ingress` with `ingressClassName: nginx-new`.
 
-**6. AWS Load Balancer Controller (ALB)**
-
-```yaml
-ingress:
-  enabled: true
-  controller: 'alb'
-  ingressClass: 'alb'
-  ingress_annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:111122223333:certificate/abc
-    alb.ingress.kubernetes.io/group.name: plane   # keep one ALB across Ingresses
-```
-
-Renders one `Ingress` with `ingressClassName: alb`. Set `ssl.externalTermination: true`
-so Plane's URLs are `https://` while the ALB holds the certificate.
-
-**7. Contour, HAProxy, Kong, Istio, Cilium, GCE, or any other controller**
-
-```yaml
-ingress:
-  enabled: true
-  controller: 'contour'   # label only — not written into any manifest
-  ingressClass: 'contour' # the class your controller watches
-```
-
-Renders one `Ingress` with `ingressClassName: contour`. Substitute your own class
-(`haproxy`, `kong`, `istio`, `cilium`, `gce`, `webapprouting.kubernetes.azure.com`, ...)
-and add that controller's annotations under `ingress_annotations`.
-
-**8. Traefik `IngressRoute` with a class name that is not `traefik*`**
+**6. Traefik `IngressRoute` with a class name that is not `traefik*`**
 
 ```yaml
 ingress:
@@ -209,7 +182,7 @@ ingress:
 Renders `IngressRoute` + `Middleware`. Useful when your platform's naming convention
 does not allow a class called `traefik`.
 
-**9. OpenShift `Route`s with a class name that is not `openshift`**
+**7. OpenShift `Route`s with a class name that is not `openshift`**
 
 ```yaml
 ingress:
@@ -222,7 +195,7 @@ ingress:
 
 Renders one `Route` per path.
 
-**10. OpenShift, letting the ingress-to-route controller convert a plain `Ingress`**
+**8. OpenShift, letting the ingress-to-route controller convert a plain `Ingress`**
 
 ```yaml
 ingress:
@@ -243,7 +216,7 @@ Renders one `Ingress` with `ingressClassName: openshift-default`. Note this path
 
    ```yaml
    ingress:
-     controller: "nginx"      # selects the standard Ingress template (anything but traefik/openshift)
+     controller: "nginx"      # selects templates/ingress-nginx.yaml
      ingressClass: "nginx"    # spec.ingressClassName — whichever class your controller exposes (e.g. "nginx-new")
    ```
 
@@ -288,7 +261,7 @@ Renders one `Ingress` with `ingressClassName: openshift-default`. Note this path
 | Value                                 | Default    | Effect                                                                                    |
 | ------------------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
 | `ingress.enabled`                     | `true`     | Master switch — set to `false` to render no ingress at all.                               |
-| `ingress.controller`                  | `''`       | Selects the resource kind: `traefik` → IngressRoute, `openshift` → Routes, anything else → standard `Ingress` with your class name. Empty = legacy selection from `ingressClass`, where only `nginx`/`openshift`/`traefik*` render anything. |
+| `ingress.controller`                  | `''`       | Selects the resource kind: `traefik` → IngressRoute, `openshift` → Routes, `nginx` → standard `Ingress` with your class name. Empty = legacy selection from `ingressClass`, where only `nginx`/`openshift`/`traefik*` render anything. |
 | `ingress.ingressClass`                | `traefik`  | Free-form `spec.ingressClassName` on the standard `Ingress`. Also drives the legacy selection while `controller` is empty. Unused by Traefik and OpenShift. |
 | `ingress.traefik.maxRequestBodyBytes` | `20971520` | Max request body size for Traefik's buffering middleware. Ignored when not using Traefik. |
 | `ingress.traefik.entryPoints`         | `[]`       | Traefik entrypoints for the `IngressRoute`. Empty means derive from your SSL settings — see below. Ignored when not using Traefik. |
@@ -567,7 +540,7 @@ ingress:
      - `planeVersion: v3.1.4 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
-     - `ingress.controller: <traefik | openshift | nginx | ... — required unless ingressClass is exactly nginx/openshift/traefik*>`
+     - `ingress.controller: <traefik | openshift | nginx — required unless ingressClass is exactly nginx/openshift/traefik*>`
      - `ingress.ingressClass: <traefik or any other ingress class configured in your cluster>`
      - `env.storageClass: <default storage class configured in your cluster>`
 
@@ -1338,7 +1311,7 @@ Note: When the email service is enabled, the cert-issuer will be automatically c
 | ingress.enabled             |                           true                            |          | Ingress setup in kubernetes is a common practice to expose application to the intended audience. Set it to `false` if you are using external ingress providers like `Cloudflare`                                                                                                                                                                                                                                          |
 | ingress.minioHost           |                                                           |          | Based on above configuration, if you want to expose the `minio` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                       |
 | ingress.rabbitmqHost        |                                                           |          | Based on above configuration, if you want to expose the `rabbitmq` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                    |
-| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; `openshift` renders one `route.openshift.io/v1 Route` per path; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress` using `ingressClass` verbatim. **Required when your class is not exactly `nginx`, `openshift` or `traefik*`** — left empty, any other class renders no ingress at all. |
+| ingress.controller          |                                                           |          | Selects the ingress resource kind. Supported: `traefik` renders a Traefik `IngressRoute`; `openshift` renders one `route.openshift.io/v1 Route` per path; `nginx` renders a standard `Ingress` using `ingressClass` verbatim. **Required when your class is not exactly `nginx`, `openshift` or `traefik*`** — left empty, any other class renders no ingress at all. |
 | ingress.ingressClass        |                          traefik                          |   Yes    | Free-form class name written to the standard `Ingress` `spec.ingressClassName` (eg. nginx, traefik, nginx-new, etc). While `controller` is empty it also selects the template, and only `nginx`, `openshift` and `traefik*` are recognised. Unused by the Traefik `IngressRoute` and by OpenShift `Route`s. |
 | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |          | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required.                                                                                                                                                                                                                                                   |
 | ingress.traefik.entryPoints |                           `[]`                            |          | Traefik entrypoints the `IngressRoute` binds to. Leave empty to derive them from your `ssl.*` settings (`websecure` when TLS is configured, otherwise `web`). Set explicitly only if your Traefik renamed the default entrypoints, e.g. `['websecure','web']`. Ignored unless the controller resolves to `traefik` |

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -77,6 +77,164 @@ The default is a Traefik `IngressRoute` (`ingressClass: traefik`, no `controller
 If you are switching to a standard ingress controller, follow the migration steps
 below.
 
+### Configuration snippets
+
+Every snippet below is the `ingress` block of your `values.yaml`. All of them also
+need `license.licenseDomain` set — no ingress of any kind renders without it:
+
+```yaml
+license:
+  licenseDomain: plane.example.com
+```
+
+#### Already supported — no `ingress.controller` needed
+
+These four worked before `ingress.controller` existed and are unchanged. Leave
+`controller` out entirely.
+
+**1. Traefik `IngressRoute` — the chart default**
+
+```yaml
+ingress:
+  enabled: true
+  ingressClass: 'traefik'
+  traefik:
+    maxRequestBodyBytes: 20971520   # 20 MiB upload cap
+    entryPoints: []                 # empty = derive from your ssl.* settings
+```
+
+Renders `IngressRoute` + `Middleware`. Requires the Traefik CRDs. Any class
+starting with `traefik` works here (`traefik-v2`, `traefikee`, ...).
+
+**2. Standard `Ingress` with ingress-nginx**
+
+```yaml
+ingress:
+  enabled: true
+  ingressClass: 'nginx'
+  ingress_annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: '20m'
+    nginx.ingress.kubernetes.io/proxy-buffer-size: '16k'   # avoids 502 "too big header"
+```
+
+Renders one `Ingress` with `ingressClassName: nginx`. The class must be exactly
+`nginx` for this to work without `controller`.
+
+**3. OpenShift `Route`s**
+
+```yaml
+ingress:
+  enabled: true
+  ingressClass: 'openshift'
+  openshift:
+    timeout: '300s'      # router default is 30s and severs /live/ WebSockets
+    termination: 'edge'  # edge | reencrypt (passthrough cannot do path routing)
+    insecureEdgeTerminationPolicy: 'Redirect'
+```
+
+Renders one `Route` per path. See [`examples/values-openshift.yaml`](examples/values-openshift.yaml)
+for a complete OpenShift values file.
+
+**4. No chart-managed ingress — bring your own**
+
+```yaml
+ingress:
+  enabled: false
+```
+
+Renders nothing at all. Use this when you expose Plane through your own `Ingress`,
+`HTTPRoute`, `LoadBalancer` Service, Cloudflare Tunnel or service mesh. This is the
+right setting if you are managing the ingress yourself — do not rely on an
+unrecognised `ingressClass` to suppress it.
+
+#### Newly possible — set `ingress.controller`
+
+Each of these rendered **no ingress at all** before this change. `controller` picks
+the resource kind; `ingressClass` is then used verbatim as `spec.ingressClassName`.
+
+**5. Standard `Ingress` with a class name that is not `nginx`** — e.g. F5 NGINX, or a
+second ingress-nginx install using a custom `IngressClass`
+
+```yaml
+ingress:
+  enabled: true
+  controller: 'nginx'        # any value but traefik*/openshift selects the Ingress
+  ingressClass: 'nginx-new'  # whatever your controller actually exposes
+  ingress_annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: '20m'
+```
+
+Renders one `Ingress` with `ingressClassName: nginx-new`.
+
+**6. AWS Load Balancer Controller (ALB)**
+
+```yaml
+ingress:
+  enabled: true
+  controller: 'alb'
+  ingressClass: 'alb'
+  ingress_annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:111122223333:certificate/abc
+    alb.ingress.kubernetes.io/group.name: plane   # keep one ALB across Ingresses
+```
+
+Renders one `Ingress` with `ingressClassName: alb`. Set `ssl.externalTermination: true`
+so Plane's URLs are `https://` while the ALB holds the certificate.
+
+**7. Contour, HAProxy, Kong, Istio, Cilium, GCE, or any other controller**
+
+```yaml
+ingress:
+  enabled: true
+  controller: 'contour'   # label only — not written into any manifest
+  ingressClass: 'contour' # the class your controller watches
+```
+
+Renders one `Ingress` with `ingressClassName: contour`. Substitute your own class
+(`haproxy`, `kong`, `istio`, `cilium`, `gce`, `webapprouting.kubernetes.azure.com`, ...)
+and add that controller's annotations under `ingress_annotations`.
+
+**8. Traefik `IngressRoute` with a class name that is not `traefik*`**
+
+```yaml
+ingress:
+  enabled: true
+  controller: 'traefik'
+  ingressClass: 'internal-lb'   # unused by the IngressRoute; kept for your own bookkeeping
+```
+
+Renders `IngressRoute` + `Middleware`. Useful when your platform's naming convention
+does not allow a class called `traefik`.
+
+**9. OpenShift `Route`s with a class name that is not `openshift`**
+
+```yaml
+ingress:
+  enabled: true
+  controller: 'openshift'
+  ingressClass: 'ocp-internal'   # unused by Routes
+  openshift:
+    timeout: '300s'
+```
+
+Renders one `Route` per path.
+
+**10. OpenShift, letting the ingress-to-route controller convert a plain `Ingress`**
+
+```yaml
+ingress:
+  enabled: true
+  controller: 'nginx'                 # emit a standard Ingress...
+  ingressClass: 'openshift-default'   # ...for OpenShift's router to convert
+```
+
+Renders one `Ingress` with `ingressClassName: openshift-default`. Note this path gets
+**no** per-route HAProxy timeout, so `/live/` WebSockets are subject to the router's
+30s default — prefer snippet 3 or 9 unless you specifically need the conversion.
+
 ### Switching from Traefik to a standard Ingress controller (e.g. nginx)
 
 1. **Install your target ingress controller** if it is not already running.

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -29,8 +29,7 @@ If you plan to use Traefik as your ingress controller, install it before deployi
 
 The chart renders one of three ingress templates. **Which one** is chosen by the
 *controller type* — kept separate from the *class name*, so atypical class names
-(e.g. `nginx-new`, or a Traefik-named alias served by a standard controller) work
-without changing template selection.
+(e.g. `nginx-new`) work without changing template selection.
 
 `ingress.controller` selects the resource kind:
 
@@ -52,10 +51,8 @@ without changing template selection.
 If `ingress.controller` is left empty, the controller is **inferred** from
 `ingress.ingressClass` for backward compatibility: a value starting with `traefik`
 selects Traefik, exactly `openshift` selects Routes, anything else selects the
-standard `Ingress`. Set `ingress.controller` explicitly to override that — for
-example to serve a standard `Ingress` whose `ingressClassName` happens to start
-with `traefik`, or to use a non-`nginx` class name like `nginx-new` (which
-previously rendered nothing at all, silently).
+standard `Ingress`. Set `ingress.controller` explicitly to use a non-`nginx` class
+name like `nginx-new` (which previously rendered nothing at all, silently).
 
 The default is a Traefik `IngressRoute` (`ingressClass: traefik`, controller
 auto-detected). If you are switching to a standard ingress controller, follow the
@@ -1164,7 +1161,7 @@ Note: When the email service is enabled, the cert-issuer will be automatically c
 | ingress.enabled             |                           true                            |          | Ingress setup in kubernetes is a common practice to expose application to the intended audience. Set it to `false` if you are using external ingress providers like `Cloudflare`                                                                                                                                                                                                                                          |
 | ingress.minioHost           |                                                           |          | Based on above configuration, if you want to expose the `minio` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                       |
 | ingress.rabbitmqHost        |                                                           |          | Based on above configuration, if you want to expose the `rabbitmq` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface.                                                                                                                                                                                                                                    |
-| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; `openshift` renders one `route.openshift.io/v1 Route` per path; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress`. Leave empty to infer it from `ingressClass`. Set explicitly for atypical class names (e.g. `nginx-new`) or a Traefik-named alias served by a standard controller.                              |
+| ingress.controller          |                                                           |          | Selects the ingress resource kind: `traefik` renders a Traefik `IngressRoute`; `openshift` renders one `route.openshift.io/v1 Route` per path; any other value (`nginx`, `f5`, `haproxy`, ...) renders a standard `Ingress`. Leave empty to infer it from `ingressClass`. Set explicitly for atypical class names (e.g. `nginx-new`).                                                                                       |
 | ingress.ingressClass        |                          traefik                          |   Yes    | Free-form class name written to the standard `Ingress` `spec.ingressClassName` (eg. nginx, traefik, nginx-new, etc). When `controller` is empty it also drives the inference. Unused by the Traefik `IngressRoute` and by OpenShift `Route`s.                                                                                                                                                                              |
 | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |          | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required.                                                                                                                                                                                                                                                   |
 | ingress.traefik.entryPoints |                           `[]`                            |          | Traefik entrypoints the `IngressRoute` binds to. Leave empty to derive them from your `ssl.*` settings (`websecure` when TLS is configured, otherwise `web`). Set explicitly only if your Traefik renamed the default entrypoints, e.g. `['websecure','web']`. Ignored unless the controller resolves to `traefik` |

--- a/charts/plane-enterprise/examples/values-openshift.yaml
+++ b/charts/plane-enterprise/examples/values-openshift.yaml
@@ -72,6 +72,8 @@ services:
 # the HAProxy timeout set explicitly. To let OpenShift's ingress-to-route
 # controller convert a plain Ingress instead, set controller: 'nginx' with
 # ingressClass: 'openshift-default' — the timeout below is then not applied.
+# Note controller must be set for that: with it empty, 'openshift-default'
+# renders no ingress at all.
 ingress:
   enabled: true
   controller: 'openshift'

--- a/charts/plane-enterprise/examples/values-openshift.yaml
+++ b/charts/plane-enterprise/examples/values-openshift.yaml
@@ -68,12 +68,13 @@ services:
 # -----------------------------------------------------------------------------
 # Ingress
 # -----------------------------------------------------------------------------
-# 'openshift' renders one route.openshift.io/v1 Route per path, with the HAProxy
-# timeout set explicitly. This is the only OpenShift ingress path the chart offers
-# — 'openshift-default' (letting the ingress-to-route controller convert a plain
-# Ingress) renders nothing, because templates/ingress.yaml is gated on 'nginx'.
+# controller: 'openshift' renders one route.openshift.io/v1 Route per path, with
+# the HAProxy timeout set explicitly. To let OpenShift's ingress-to-route
+# controller convert a plain Ingress instead, set controller: 'nginx' with
+# ingressClass: 'openshift-default' — the timeout below is then not applied.
 ingress:
   enabled: true
+  controller: 'openshift'
   ingressClass: 'openshift'
   openshift:
     # The router default is 30s, which severs /live/'s collaborative-editing

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -1420,7 +1420,7 @@ questions:
     label: "Ingress Classname"
     type: string
     required: true
-    default: "nginx"
+    default: "traefik"
     show_if: "ingress.enabled=true"
 
 - variable: ssl.createIssuer

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -1716,16 +1716,16 @@ questions:
     show_if: "services.rabbitmq.local_setup=true"
   - variable: ingress.controller
     label: "Ingress Controller Type"
-    description: "Which kind of ingress resource to render: 'traefik' a Traefik IngressRoute, 'openshift' one OpenShift Route per path, anything else ('nginx', 'f5', 'haproxy', ...) a standard networking.k8s.io/v1 Ingress. Leave empty to infer it from the Ingress Classname below. Set it explicitly when your class name is atypical, e.g. 'nginx-new'."
+    description: "Which kind of ingress resource to render: 'traefik' a Traefik IngressRoute, 'openshift' one OpenShift Route per path, anything else ('nginx', 'f5', 'haproxy', 'alb', ...) a standard networking.k8s.io/v1 Ingress using the Ingress Classname below verbatim. REQUIRED when your class name is not exactly 'nginx', 'openshift' or 'traefik*' - left empty, any other class renders no ingress at all."
     type: string
     default: ""
     show_if: "ingress.enabled=true"
   - variable: ingress.ingressClass
     label: "Ingress Classname"
-    description: "Class name written to the standard Ingress' spec.ingressClassName. Unused by the Traefik IngressRoute and by OpenShift Routes. When the Ingress Controller Type above is empty this also selects which template renders."
+    description: "Class name written to the standard Ingress' spec.ingressClassName. Unused by the Traefik IngressRoute and by OpenShift Routes. While Ingress Controller Type above is empty this also selects which template renders, and only 'nginx', 'openshift' and 'traefik*' are recognised."
     type: string
     required: true
-    default: "traefik"
+    default: "nginx"
     show_if: "ingress.enabled=true"
 
 - variable: ssl.createIssuer

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -1714,11 +1714,18 @@ questions:
     type: string
     default: ""
     show_if: "services.rabbitmq.local_setup=true"
+  - variable: ingress.controller
+    label: "Ingress Controller Type"
+    description: "Which kind of ingress resource to render: 'traefik' a Traefik IngressRoute, 'openshift' one OpenShift Route per path, anything else ('nginx', 'f5', 'haproxy', ...) a standard networking.k8s.io/v1 Ingress. Leave empty to infer it from the Ingress Classname below. Set it explicitly when your class name is atypical, e.g. 'nginx-new'."
+    type: string
+    default: ""
+    show_if: "ingress.enabled=true"
   - variable: ingress.ingressClass
     label: "Ingress Classname"
+    description: "Class name written to the standard Ingress' spec.ingressClassName. Unused by the Traefik IngressRoute and by OpenShift Routes. When the Ingress Controller Type above is empty this also selects which template renders."
     type: string
     required: true
-    default: "nginx"
+    default: "traefik"
     show_if: "ingress.enabled=true"
 
 - variable: ssl.createIssuer
@@ -1773,7 +1780,7 @@ questions:
 
 - variable: ingress.traefik.entryPoints
   label: "Traefik Entrypoints Override"
-  description: "Traefik entrypoints the IngressRoute binds to, e.g. 'websecure'. Leave empty to derive from the SSL settings (websecure when this chart manages a certificate, otherwise web). Required as 'websecure' when TLS is terminated by Traefik's own entrypoint. Ignored unless the ingress class is traefik."
+  description: "Traefik entrypoints the IngressRoute binds to, e.g. 'websecure'. Leave empty to derive from the SSL settings (websecure when this chart manages a certificate, otherwise web). Required as 'websecure' when TLS is terminated by Traefik's own entrypoint. Ignored unless the controller resolves to traefik."
   type: string
   default: ""
   group: "Ingress"

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -1716,7 +1716,7 @@ questions:
     show_if: "services.rabbitmq.local_setup=true"
   - variable: ingress.controller
     label: "Ingress Controller Type"
-    description: "Which kind of ingress resource to render: 'traefik' a Traefik IngressRoute, 'openshift' one OpenShift Route per path, anything else ('nginx', 'f5', 'haproxy', 'alb', ...) a standard networking.k8s.io/v1 Ingress using the Ingress Classname below verbatim. REQUIRED when your class name is not exactly 'nginx', 'openshift' or 'traefik*' - left empty, any other class renders no ingress at all."
+    description: "Which kind of ingress resource to render. Supported: 'traefik' a Traefik IngressRoute, 'openshift' one OpenShift Route per path, 'nginx' a standard networking.k8s.io/v1 Ingress using the Ingress Classname below verbatim. REQUIRED when your class name is not exactly 'nginx', 'openshift' or 'traefik*' - left empty, any other class renders no ingress at all."
     type: string
     default: ""
     show_if: "ingress.enabled=true"

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -65,6 +65,36 @@ of the local_setup flag's value.
 {{- end -}}
 
 {{/*
+Selects which ingress template renders, decoupling the controller *type* (which
+resource kind to emit) from the ingress *class name* (a free-form string).
+
+Returns one of:
+  - "traefik" -> templates/ingress-traefik.yaml emits a traefik.io/v1alpha1 IngressRoute
+  - "ingress" -> templates/ingress.yaml emits a networking.k8s.io/v1 Ingress
+                 (nginx, F5 NGINX, HAProxy, or any other standard controller)
+
+Resolution order:
+  1. If ingress.controller is set explicitly, it wins. Only the literal value
+     "traefik" selects the IngressRoute path; any other value (e.g. "nginx",
+     "f5", "haproxy") selects the standard Ingress path. This lets atypical
+     class names like "nginx-new" be used without affecting template selection.
+  2. Otherwise (legacy behavior) the choice is inferred from ingress.ingressClass:
+     a value starting with "traefik" selects Traefik, anything else selects the
+     standard Ingress. Set ingress.controller to override the inference (e.g. a
+     standard Ingress whose ingressClassName happens to start with "traefik").
+*/}}
+{{- define "plane.ingressController" -}}
+  {{- $c := .Values.ingress.controller | default "" | lower | trim -}}
+  {{- if $c -}}
+    {{- if eq $c "traefik" -}}traefik{{- else -}}ingress{{- end -}}
+  {{- else if hasPrefix "traefik" (.Values.ingress.ingressClass | default "" | lower) -}}
+    traefik
+  {{- else -}}
+    ingress
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Normalize the deprecated s3SecretName/s3SecretKey into the s3Secrets list format.
 Returns "true" when airgapped is enabled and at least one CA secret is configured.
 */}}

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -99,6 +99,28 @@ of the local_setup flag's value.
 {{- end -}}
 
 {{/*
+Selects which ingress template renders, decoupling the controller *type* (which
+resource kind to emit) from the ingress *class name* (a free-form string).
+Returns "traefik" (IngressRoute), "openshift" (Route per path), or "ingress"
+(networking.k8s.io/v1 Ingress -- nginx, F5 NGINX, HAProxy, ALB, anything else).
+
+ingress.controller decides when set; otherwise the value is inferred from
+ingress.ingressClass, which is the pre-existing behaviour. Set controller to
+override that inference -- an atypical class name such as "nginx-new", or a
+Traefik-named class that should still be served by a standard Ingress.
+*/}}
+{{- define "plane.ingressController" -}}
+  {{- $c := .Values.ingress.controller | default "" | trim | lower -}}
+  {{- if not $c -}}
+    {{- $c = .Values.ingress.ingressClass | default "" | trim | lower -}}
+  {{- end -}}
+  {{- if hasPrefix "traefik" $c -}}traefik
+  {{- else if eq $c "openshift" -}}openshift
+  {{- else -}}ingress
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Normalize the deprecated s3SecretName/s3SecretKey into the s3Secrets list format.
 Returns "true" when airgapped is enabled and at least one CA secret is configured.
 */}}

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -102,10 +102,12 @@ of the local_setup flag's value.
 Selects which ingress template renders, decoupling the controller *type* (which
 resource kind to emit) from the ingress *class name* (a free-form string).
 Returns "traefik" (IngressRoute), "openshift" (Route per path), "ingress"
-(networking.k8s.io/v1 Ingress) or "none" (render nothing).
+(networking.k8s.io/v1 Ingress, i.e. ingress-nginx) or "none" (render nothing).
 
 ingress.controller decides when set: "traefik*" -> traefik, "openshift" ->
-openshift, anything else -> a standard Ingress, whatever the class name is.
+openshift, anything else -> a standard Ingress, whatever the class name is. That
+last case exists so a non-"nginx" class name can still be served, e.g.
+controller "nginx" with ingressClass "nginx-new".
 
 When ingress.controller is EMPTY the selection is the pre-3.5.5 one, exactly:
 only "traefik*", "openshift" and "nginx" are recognised and any other class

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -101,22 +101,33 @@ of the local_setup flag's value.
 {{/*
 Selects which ingress template renders, decoupling the controller *type* (which
 resource kind to emit) from the ingress *class name* (a free-form string).
-Returns "traefik" (IngressRoute), "openshift" (Route per path), or "ingress"
-(networking.k8s.io/v1 Ingress -- nginx, F5 NGINX, HAProxy, ALB, anything else).
+Returns "traefik" (IngressRoute), "openshift" (Route per path), "ingress"
+(networking.k8s.io/v1 Ingress) or "none" (render nothing).
 
-ingress.controller decides when set; otherwise the value is inferred from
-ingress.ingressClass, which is the pre-existing behaviour. Set controller to
-override that inference -- an atypical class name such as "nginx-new", or a
-Traefik-named class that should still be served by a standard Ingress.
+ingress.controller decides when set: "traefik*" -> traefik, "openshift" ->
+openshift, anything else -> a standard Ingress, whatever the class name is.
+
+When ingress.controller is EMPTY the selection is the pre-3.5.5 one, exactly:
+only "traefik*", "openshift" and "nginx" are recognised and any other class
+returns "none", rendering no ingress. That silent no-op is kept deliberately --
+widening it would make an upgrade create a <release>-ingress for operators who
+are on such a class today and already run an ingress of their own. Set
+ingress.controller to opt into the standard Ingress for any class name.
 */}}
 {{- define "plane.ingressController" -}}
   {{- $c := .Values.ingress.controller | default "" | trim | lower -}}
-  {{- if not $c -}}
-    {{- $c = .Values.ingress.ingressClass | default "" | trim | lower -}}
-  {{- end -}}
-  {{- if hasPrefix "traefik" $c -}}traefik
-  {{- else if eq $c "openshift" -}}openshift
-  {{- else -}}ingress
+  {{- if $c -}}
+    {{- if hasPrefix "traefik" $c -}}traefik
+    {{- else if eq $c "openshift" -}}openshift
+    {{- else -}}ingress
+    {{- end -}}
+  {{- else -}}
+    {{- $k := .Values.ingress.ingressClass | default "" -}}
+    {{- if hasPrefix "traefik" $k -}}traefik
+    {{- else if eq $k "openshift" -}}openshift
+    {{- else if eq $k "nginx" -}}ingress
+    {{- else -}}none
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/plane-enterprise/templates/ingress-nginx.yaml
+++ b/charts/plane-enterprise/templates/ingress-nginx.yaml
@@ -1,9 +1,12 @@
 {{/*
-Standard networking.k8s.io/v1 Ingress. Which of the three ingress templates
-renders is decided by the "plane.ingressController" helper, not by ingressClass
-directly. This one covers every controller that is not Traefik or OpenShift, but
-only once ingress.controller is set -- with it empty the helper still recognises
-"nginx" alone, so an unrecognised class renders nothing (see the helper).
+Standard networking.k8s.io/v1 Ingress, for ingress-nginx. Which of the three
+ingress templates renders is decided by the "plane.ingressController" helper, not
+by ingressClass directly.
+
+The resource itself is controller-agnostic, so setting ingress.controller to
+something other than traefik/openshift also renders from here -- that is how a
+non-"nginx" class name such as "nginx-new" is served. Only nginx, Traefik and
+OpenShift are supported configurations.
 */}}
 {{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "ingress") .Values.license.licenseDomain }}
 

--- a/charts/plane-enterprise/templates/ingress-openshift.yaml
+++ b/charts/plane-enterprise/templates/ingress-openshift.yaml
@@ -41,7 +41,7 @@ Differences from the Traefik IngressRoute this mirrors:
 {{- fail (printf "ingress.openshift.termination must be \"edge\" or \"reencrypt\", got %q. Path-based Routes cannot use passthrough termination; see charts/plane-enterprise/README.md." $termination) }}
 {{- end }}
 
-{{/* Same path -> service mapping as templates/ingress.yaml, most specific first
+{{/* Same path -> service mapping as templates/ingress-nginx.yaml, most specific first
      (ordering is cosmetic here, kept aligned so the two are easy to diff). */}}
 {{- $routes := list
       (dict "slug" "spaces"      "path" "/spaces/"      "svc" (printf "%s-space" $name) "port" 3000)
@@ -65,7 +65,7 @@ Differences from the Traefik IngressRoute this mirrors:
 {{- $routes = append $routes (dict "slug" "web" "path" "/" "svc" (printf "%s-web" $name) "port" 3000) }}
 
 {{/* The bundled MinIO console and RabbitMQ management UI live on their own hosts,
-     matching templates/ingress.yaml. Both are gated on the corresponding
+     matching templates/ingress-nginx.yaml. Both are gated on the corresponding
      local_setup, so neither renders in the recommended OpenShift configuration
      (where the bundled datastores are off because they cannot run under an
      arbitrary UID) -- they are here for a cluster that grants those workloads a

--- a/charts/plane-enterprise/templates/ingress-openshift.yaml
+++ b/charts/plane-enterprise/templates/ingress-openshift.yaml
@@ -2,18 +2,19 @@
 ================================================================================
 OpenShift ingress: one route.openshift.io/v1 Route per path.
 ================================================================================
-Rendered when ingress.ingressClass == "openshift".
+Rendered when "plane.ingressController" resolves to "openshift", i.e.
+ingress.controller (or, unset, ingress.ingressClass) is "openshift".
 
 Why explicit Routes rather than a plain Ingress:
 
 OpenShift's ingress-to-route controller can convert a networking.k8s.io/v1
-Ingress into Routes. This chart does not offer that path: templates/ingress.yaml
-is gated on ingressClass == "nginx", so setting "openshift-default" renders
-nothing. Declaring the Routes here is also the more predictable option — the
-conversion only picks up an Ingress whose class maps to the
+Ingress into Routes, but declaring the Routes here is the more predictable
+option — the conversion only picks up an Ingress whose class maps to the
 openshift.io/ingress-to-route controller, and whether per-path HAProxy
 annotations survive it varies by OCP version. Plane needs the timeout below, so
-there is no guesswork this way.
+there is no guesswork this way. (If you do want that path, set
+ingress.controller to "nginx" with ingressClass "openshift-default" and the
+standard Ingress renders instead.)
 
 Differences from the Traefik IngressRoute this mirrors:
 
@@ -26,7 +27,7 @@ Differences from the Traefik IngressRoute this mirrors:
   - Path-based Routes require edge or reencrypt TLS termination; they are not
     supported with passthrough.
 */}}
-{{- if and .Values.ingress.enabled (eq .Values.ingress.ingressClass "openshift") .Values.license.licenseDomain }}
+{{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "openshift") .Values.license.licenseDomain }}
 {{- $host := .Values.license.licenseDomain }}
 {{- $name := .Release.Name }}
 {{- $oc := .Values.ingress.openshift | default dict }}

--- a/charts/plane-enterprise/templates/ingress-traefik.yaml
+++ b/charts/plane-enterprise/templates/ingress-traefik.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled (hasPrefix "traefik" .Values.ingress.ingressClass) .Values.license.licenseDomain }}
+{{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "traefik") .Values.license.licenseDomain }}
 
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -1,13 +1,13 @@
-{{- if and .Values.ingress.enabled (eq .Values.ingress.ingressClass "nginx") .Values.license.licenseDomain }}
+{{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "ingress") .Values.license.licenseDomain }}
 
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ingress
-  {{- if gt (len .Values.ingress.ingress_annotations) 0 }}
+  {{- with .Values.ingress.ingress_annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.ingress_annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -1,15 +1,9 @@
 {{/*
-Standard networking.k8s.io/v1 Ingress. Gated on ingressClass being exactly
-"nginx"; the other templates are ingress-traefik.yaml ("traefik*") and
-ingress-openshift.yaml ("openshift").
-
-NOTE: any other class (alb, haproxy, contour, openshift-default, a custom
-IngressClass name, ...) renders nothing at all, with no error -- despite the
-README describing this template as the fallback for "any other value". That
-mismatch is deliberately left as-is for now and tracked separately; do not widen
-this condition without checking what else assumes the nginx-only behaviour.
+Standard networking.k8s.io/v1 Ingress -- the fallback for every controller that
+is not Traefik or OpenShift. Which of the three ingress templates renders is
+decided by the "plane.ingressController" helper, not by ingressClass directly.
 */}}
-{{- if and .Values.ingress.enabled (eq .Values.ingress.ingressClass "nginx") .Values.license.licenseDomain }}
+{{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "ingress") .Values.license.licenseDomain }}
 
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{/*
-Standard networking.k8s.io/v1 Ingress -- the fallback for every controller that
-is not Traefik or OpenShift. Which of the three ingress templates renders is
-decided by the "plane.ingressController" helper, not by ingressClass directly.
+Standard networking.k8s.io/v1 Ingress. Which of the three ingress templates
+renders is decided by the "plane.ingressController" helper, not by ingressClass
+directly. This one covers every controller that is not Traefik or OpenShift, but
+only once ingress.controller is set -- with it empty the helper still recognises
+"nginx" alone, so an unrecognised class renders nothing (see the helper).
 */}}
 {{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "ingress") .Values.license.licenseDomain }}
 

--- a/charts/plane-enterprise/templates/traefik-middleware.yaml
+++ b/charts/plane-enterprise/templates/traefik-middleware.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled (hasPrefix "traefik" .Values.ingress.ingressClass) }}
+{{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "traefik") }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:

--- a/charts/plane-enterprise/templates/traefik-middleware.yaml
+++ b/charts/plane-enterprise/templates/traefik-middleware.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled (hasPrefix "traefik" .Values.ingress.ingressClass) }}
+{{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "traefik") .Values.license.licenseDomain }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -38,10 +38,23 @@ ingress:
   enabled: true
   minioHost: ''
   rabbitmqHost: ''
+  # controller selects WHICH KIND of ingress resource the chart renders, decoupled
+  # from the class name below. Only the literal value "traefik" emits a Traefik
+  # IngressRoute CRD; any other value ("nginx", "f5", "haproxy", ...) emits a standard
+  # networking.k8s.io/v1 Ingress. Leave empty to auto-detect from ingressClass
+  # (a value starting with "traefik" -> Traefik, otherwise standard Ingress).
+  # Set this explicitly when your ingressClass is an atypical name (e.g. "nginx-new")
+  # or a Traefik-named alias that should still be served by a standard Ingress.
+  controller: ''
+  # ingressClass is the free-form class name written to the standard Ingress'
+  # spec.ingressClassName. It no longer constrains which template renders (use
+  # controller above for that). With controller="traefik" it is unused, since an
+  # IngressRoute has no class name.
   ingressClass: 'traefik'
-  # If using nginx ingress controller, set this to 'nginx' and add the appropriate annotations to set the proxy body size limit.
-  # These annotations are ONLY rendered when ingressClass is 'nginx' (the nginx Ingress template is gated on
-  # ingressClass == "nginx"); they have no effect with traefik. Example:
+  # For standard Ingress controllers (controller != "traefik") set the proxy body
+  # size / buffer annotations here. These are rendered onto the standard Ingress
+  # only; they have no effect with Traefik (use ingress.traefik.maxRequestBodyBytes).
+  # Example for ingress-nginx:
   # - proxy-body-size: nginx equivalent of traefik's maxRequestBodyBytes (upload size limit).
   # - proxy-buffer-size: size of the buffer for the response headers from upstream; bump this to avoid
   #   "502 upstream sent too big header" errors.

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -43,8 +43,7 @@ ingress:
   # IngressRoute CRD; any other value ("nginx", "f5", "haproxy", ...) emits a standard
   # networking.k8s.io/v1 Ingress. Leave empty to auto-detect from ingressClass
   # (a value starting with "traefik" -> Traefik, otherwise standard Ingress).
-  # Set this explicitly when your ingressClass is an atypical name (e.g. "nginx-new")
-  # or a Traefik-named alias that should still be served by a standard Ingress.
+  # Set this explicitly when your ingressClass is an atypical name (e.g. "nginx-new").
   controller: ''
   # ingressClass is the free-form class name written to the standard Ingress'
   # spec.ingressClassName. It no longer constrains which template renders (use

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -47,7 +47,7 @@ ingress:
   # Leave empty to infer it from ingressClass: a value starting with 'traefik'
   # means Traefik, exactly 'openshift' means Routes, everything else means a
   # standard Ingress. Set it explicitly when your class name is atypical
-  # (e.g. 'nginx-new', or a Traefik-named alias served by a standard Ingress).
+  # (e.g. 'nginx-new').
   controller: ''
   # ingressClass is the free-form class name written to the standard Ingress'
   # spec.ingressClassName. It no longer constrains which template renders (use

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -39,18 +39,18 @@ ingress:
   minioHost: ''
   rabbitmqHost: ''
   # controller selects WHICH KIND of ingress resource is rendered, decoupled from
-  # the class name below. When set:
+  # the class name below. Supported: nginx, traefik and openshift. When set:
   #   'traefik'   -> Traefik IngressRoute CRD      (templates/ingress-traefik.yaml)
   #   'openshift' -> one OpenShift Route per path  (templates/ingress-openshift.yaml)
-  #   anything else ('nginx', 'f5', 'haproxy', 'alb', ...)
-  #               -> networking.k8s.io/v1 Ingress (templates/ingress.yaml), with
-  #                  ingressClass below used verbatim as spec.ingressClassName.
+  #   'nginx' (or any other value)
+  #               -> networking.k8s.io/v1 Ingress (templates/ingress-nginx.yaml),
+  #                  with ingressClass below used verbatim as spec.ingressClassName.
   # Leave it empty and the legacy selection applies, unchanged: only a class of
   # 'traefik*', 'openshift' or 'nginx' renders anything, and ANY OTHER class
   # renders no ingress at all, silently. That is kept so upgrades never create an
   # ingress where the chart previously created none.
-  # => Set controller whenever your class is not exactly 'nginx'/'traefik*'/
-  #    'openshift' -- e.g. 'nginx-new', 'alb', 'contour', 'istio', 'gce'.
+  # => Set controller when your class name is not exactly 'nginx', 'openshift' or
+  #    'traefik*' -- e.g. controller 'nginx' with ingressClass 'nginx-new'.
   controller: ''
   # ingressClass is the free-form class name written to the standard Ingress'
   # spec.ingressClassName. Unused on the traefik and openshift paths, since

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -39,20 +39,23 @@ ingress:
   minioHost: ''
   rabbitmqHost: ''
   # controller selects WHICH KIND of ingress resource is rendered, decoupled from
-  # the class name below. Recognised values:
+  # the class name below. When set:
   #   'traefik'   -> Traefik IngressRoute CRD      (templates/ingress-traefik.yaml)
   #   'openshift' -> one OpenShift Route per path  (templates/ingress-openshift.yaml)
   #   anything else ('nginx', 'f5', 'haproxy', 'alb', ...)
-  #               -> networking.k8s.io/v1 Ingress (templates/ingress.yaml)
-  # Leave empty to infer it from ingressClass: a value starting with 'traefik'
-  # means Traefik, exactly 'openshift' means Routes, everything else means a
-  # standard Ingress. Set it explicitly when your class name is atypical
-  # (e.g. 'nginx-new').
+  #               -> networking.k8s.io/v1 Ingress (templates/ingress.yaml), with
+  #                  ingressClass below used verbatim as spec.ingressClassName.
+  # Leave it empty and the legacy selection applies, unchanged: only a class of
+  # 'traefik*', 'openshift' or 'nginx' renders anything, and ANY OTHER class
+  # renders no ingress at all, silently. That is kept so upgrades never create an
+  # ingress where the chart previously created none.
+  # => Set controller whenever your class is not exactly 'nginx'/'traefik*'/
+  #    'openshift' -- e.g. 'nginx-new', 'alb', 'contour', 'istio', 'gce'.
   controller: ''
   # ingressClass is the free-form class name written to the standard Ingress'
-  # spec.ingressClassName. It no longer constrains which template renders (use
-  # controller above for that). Unused on the traefik and openshift paths, since
-  # neither an IngressRoute nor a Route carries a class name.
+  # spec.ingressClassName. Unused on the traefik and openshift paths, since
+  # neither an IngressRoute nor a Route carries a class name. It also drives the
+  # legacy selection above while controller is empty.
   ingressClass: 'traefik'
   # Annotations for the standard Ingress — e.g. to set the proxy body size limit
   # on the nginx controller. Rendered onto the standard Ingress only; they have no

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -38,16 +38,27 @@ ingress:
   enabled: true
   minioHost: ''
   rabbitmqHost: ''
-  # Selects which ingress template is rendered:
-  #   'traefik*'          -> Traefik IngressRoute CRD      (templates/ingress-traefik.yaml)
-  #   'openshift'         -> OpenShift Route per path      (templates/ingress-openshift.yaml)
-  #   'nginx'             -> networking.k8s.io/v1 Ingress  (templates/ingress.yaml)
-  # Any OTHER value renders no ingress at all -- see the note in templates/ingress.yaml.
+  # controller selects WHICH KIND of ingress resource is rendered, decoupled from
+  # the class name below. Recognised values:
+  #   'traefik'   -> Traefik IngressRoute CRD      (templates/ingress-traefik.yaml)
+  #   'openshift' -> one OpenShift Route per path  (templates/ingress-openshift.yaml)
+  #   anything else ('nginx', 'f5', 'haproxy', 'alb', ...)
+  #               -> networking.k8s.io/v1 Ingress (templates/ingress.yaml)
+  # Leave empty to infer it from ingressClass: a value starting with 'traefik'
+  # means Traefik, exactly 'openshift' means Routes, everything else means a
+  # standard Ingress. Set it explicitly when your class name is atypical
+  # (e.g. 'nginx-new', or a Traefik-named alias served by a standard Ingress).
+  controller: ''
+  # ingressClass is the free-form class name written to the standard Ingress'
+  # spec.ingressClassName. It no longer constrains which template renders (use
+  # controller above for that). Unused on the traefik and openshift paths, since
+  # neither an IngressRoute nor a Route carries a class name.
   ingressClass: 'traefik'
-  # Annotations for the standard Ingress — e.g. to set the proxy body size limit on
-  # the nginx controller. ONLY rendered when ingressClass is exactly 'nginx'; they
-  # have no effect with traefik, and the 'openshift' Route path takes its
-  # annotations from ingress.openshift.route_annotations instead. Example:
+  # Annotations for the standard Ingress — e.g. to set the proxy body size limit
+  # on the nginx controller. Rendered onto the standard Ingress only; they have no
+  # effect with traefik (use ingress.traefik.maxRequestBodyBytes) and the openshift
+  # path takes its annotations from ingress.openshift.route_annotations instead.
+  # Example for ingress-nginx:
   # - proxy-body-size: nginx equivalent of traefik's maxRequestBodyBytes (upload size limit).
   # - proxy-buffer-size: size of the buffer for the response headers from upstream; bump this to avoid
   #   "502 upstream sent too big header" errors.
@@ -64,7 +75,7 @@ ingress:
     # Set explicitly only if your Traefik install renamed the default entrypoints,
     # e.g. entryPoints: ['websecure', 'web'] or ['https'].
     entryPoints: []
-  # Only read when ingressClass is 'openshift'.
+  # Only read on the openshift path (see controller above).
   openshift:
     # HAProxy's per-route timeout. The router default is 30s, which severs
     # /live/'s collaborative-editing WebSockets and /pi/'s streaming responses.


### PR DESCRIPTION
## What

Decouples the **ingress controller type** (which resource kind to render) from the **ingress class name** in `plane-enterprise`, via a new `ingress.controller` value.

- `templates/_helpers.tpl` — new `plane.ingressController` helper. When `controller` is set it resolves to `traefik` → Traefik `IngressRoute`, `openshift` → one `route.openshift.io/v1 Route` per path, or anything else → standard `networking.k8s.io/v1 Ingress` **using `ingressClass` verbatim**. When `controller` is empty it reproduces the pre-3.5.5 selection exactly.
- `templates/ingress.yaml` — gate changed from `eq .Values.ingress.ingressClass "nginx"` to the helper, so a standard `Ingress` can be rendered for any class name.
- `templates/ingress-traefik.yaml`, `templates/ingress-openshift.yaml`, `templates/traefik-middleware.yaml` — re-gated on the same helper, so all four templates agree on one selection rule.
- `values.yaml` — added documented `ingress.controller: ''`.
- `questions.yml` — added `ingress.controller` so the Rancher form can reach it.
- `README.md`, `examples/values-openshift.yaml` — documented the selection rules.
- `Chart.yaml` — `version` 3.5.4 → 3.5.5 (`appVersion` unchanged).

```diff
- {{- if and .Values.ingress.enabled (eq .Values.ingress.ingressClass "nginx") .Values.license.licenseDomain }}
+ {{- if and .Values.ingress.enabled (eq (include "plane.ingressController" .) "ingress") .Values.license.licenseDomain }}
```

## Why

`ingress.ingressClass` was overloaded to pick **both** the resource kind **and** the class-name string. The standard `Ingress` rendered only for the exact value `nginx`, so a standard controller using any other class name got **no ingress at all**, with no error and no resource — a successful-looking `helm install` with nothing reachable. Operators had to hand-roll an ingress and keep its routes in sync by hand.

`ingress.controller` lets an operator state the controller type explicitly and use whatever class name their controller exposes (`nginx-new`, `alb`, `contour`, ...). It also resolves the gap `templates/ingress.yaml` flagged in its own comment on `master`: *"despite the README describing this template as the fallback for 'any other value'... tracked separately"*.

## Scope / behavior

**This is a zero-diff upgrade.** `ingress.controller` defaults to `''`, and while it is empty the helper reproduces the pre-3.5.5 selection byte-for-byte, including its case sensitivity:

| `ingressClass` with no `controller` | Renders |
| --- | --- |
| `traefik`, or anything starting with it | Traefik `IngressRoute` |
| `openshift` | OpenShift `Route`s |
| `nginx` | Standard `Ingress` |
| anything else | nothing, as before |

The new standard-`Ingress`-for-any-class behavior is reached **only** when an operator sets `ingress.controller`. Nothing changes for anyone until they opt in.

### Why the fallback is opt-in rather than simply widened

An earlier revision of this branch widened the fallback unconditionally, so any class outside `{traefik*, nginx, openshift}` rendered a standard `Ingress`. An upgrade review of 3.5.2 → 3.5.5 showed that is not a safe default:

- Operators on `alb`, `contour`, `istio`, `gce`, `nginx-new`, `openshift-default`, a custom `IngressClass` name or an empty string get **no ingress from 3.5.2**, so they necessarily run one of their own.
- On upgrade they would get a **second `Ingress` for the same host** — which on the AWS LB controller means a **second ALB** provisioned, unless an `IngressGroup` is set.
- Or the **upgrade fails outright** if their own ingress is already named `<release>-ingress`, since Helm will not adopt a resource it does not own (`invalid ownership metadata`).

Keeping the no-op as the default and gating the new behavior behind `ingress.controller` removes that entirely, at the cost of leaving the silent no-op in place for operators who do not set `controller`. The README now documents that no-op prominently, with the exact list of class names it affects.

Other notes:

- `traefik-middleware.yaml` now matches `ingress-traefik.yaml`'s gate exactly, `licenseDomain` included. Previously the `Middleware` could render without its `IngressRoute` (an orphan CRD, reproducible on `master` with `licenseDomain` empty).
- `ingress-openshift.yaml` had to be re-gated on the helper too. It was gated independently on `eq ingressClass "openshift"`; had it been left alone, a `controller` resolving to `ingress` for the `openshift` class would emit **both** 10 `Route`s and a standard `Ingress`.
- `ingress.ingress_annotations` still render only on the standard `Ingress`; the `openshift` path continues to use `ingress.openshift.route_annotations`.
- No changes to host mapping (`license.licenseDomain`), TLS (`ssl.*`), or any non-ingress template.

## Testing

`helm lint` clean.

**Upgrade safety — rendered manifests, 3.5.2 vs this branch.** Chart/app version labels and the `timestamp: {{ now }}` annotations were normalised, with a same-chart-twice self-check at 0 differing lines to prove the normalisation was complete.

| Scenario | Result |
| --- | --- |
| 22 `ingressClass` values — `traefik`, `traefik-v2`, `traefikee`, `Traefik`, `TRAEFIK`, `nginx`, `nginx-new`, `nginx-internal`, `openshift`, `openshift-default`, `alb`, `aws-alb`, `haproxy`, `contour`, `istio`, `kong`, `ambassador`, `cilium`, `gce`, `azure/application-gateway`, `webapprouting.kubernetes.azure.com`, `''` | **all identical** |
| `ingress.enabled=false` | identical |
| `license.licenseDomain` empty | identical |
| `-f examples/values-openshift.yaml` | identical |

**The feature, with `controller` set**

| Values | Rendered | `ingressClassName` |
| --- | --- | --- |
| `controller: nginx`, `ingressClass: nginx-new` | `Ingress` | `nginx-new` |
| `controller: f5`, `ingressClass: nginx-new` | `Ingress` | `nginx-new` |
| `controller: alb`, `ingressClass: alb` | `Ingress` | `alb` |
| `controller: contour`, `ingressClass: contour` | `Ingress` | `contour` |
| `controller: nginx`, `ingressClass: openshift-default` | `Ingress` | `openshift-default` |
| `controller: traefik`, `ingressClass: nginx` | `IngressRoute` + `Middleware` | — |
| `controller: openshift`, `ingressClass: whatever` | 10 × `Route` | — |
| `controller: "NGINX "` (case + whitespace) | `Ingress` | `nginx-new` |

**Legacy path, `controller` unset** — `traefik` → `IngressRoute` + `Middleware`; `nginx` → `Ingress`; `openshift` → 10 × `Route`; `alb` and `nginx-new` → nothing, unchanged.

Not tested against a live cluster: the Helm ownership-conflict failure described above is Helm's documented adoption behavior, not something executed here.

## Upgrade notes

**No action required, and no rendered change, for any existing values file.**

Operators currently on a class the chart does not recognise (`alb`, `contour`, `istio`, `gce`, `nginx-new`, `openshift-default`, ...) still get no ingress from the chart, exactly as before. To have the chart manage the ingress instead of their own, they set `ingress.controller` — and should delete their hand-rolled ingress in the same change, since both would otherwise serve the same host.

## Related

- Rebased onto `master` at `8965942`, picking up the OpenShift `Route` path (`templates/ingress-openshift.yaml`) that landed after this branch was opened. The three-way helper and the `ingress-openshift.yaml` re-gate are the result.
- `plane-ce` does **not** need the equivalent change: its `templates/ingress.yaml` is already gated on `not (hasPrefix "traefik" ...)`, so non-traefik class names always rendered a standard `Ingress` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
