### PR TITLE
[INFRA-423] - feat(plane-ce): add standard Kubernetes recommended labels

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.5.1
+version: 1.5.2
 appVersion: "1.3.1"
 
 home: https://plane.so

--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.5.2
+version: 1.6.0
 appVersion: "1.3.1"
 
 home: https://plane.so

--- a/charts/plane-ce/templates/_helpers.tpl
+++ b/charts/plane-ce/templates/_helpers.tpl
@@ -14,11 +14,45 @@
   {{- end }}
 {{- end }}
 
-{{- define "plane.labelsAndAnnotations" -}}
-  {{- with .labels }}
-  labels: {{ toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .annotations }}
+{{/*
+Chart name and version, sanitized for use as the `helm.sh/chart` label value.
+*/}}
+{{- define "plane.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Standard Kubernetes recommended labels shared by every resource the chart renders.
+These are additive metadata labels only; they are intentionally kept out of
+spec.selector/matchLabels (which stay on the immutable `app.name` label) so that
+upgrading an existing release never tries to mutate an immutable selector.
+Call with the root context, e.g. {{ include "plane.commonLabels" $ }}
+*/}}
+{{- define "plane.commonLabels" -}}
+helm.sh/chart: {{ include "plane.chart" . }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Render a resource's `labels` and `annotations` metadata.
+Always emits the standard recommended labels (see plane.commonLabels) and merges
+any per-component labels supplied under the component's `labels` value. Per-component
+annotations are emitted when present.
+Call with a dict carrying the root context and the component values:
+  {{ include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
+*/}}
+{{- define "plane.labelsAndAnnotations" }}
+  labels:
+    {{- include "plane.commonLabels" .context | nindent 4 }}
+    {{- with .values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .values.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/plane-ce/templates/certs/cert-issuers.yaml
+++ b/charts/plane-ce/templates/certs/cert-issuers.yaml
@@ -5,6 +5,8 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-issuer-api-token-secret
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 type: Opaque
 stringData:
   api-token: {{ .Values.ssl.token | default "default-api-token" | quote }}
@@ -15,6 +17,8 @@ kind: Issuer
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-cert-issuer
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   acme:
     email: {{ .Values.ssl.email }}

--- a/charts/plane-ce/templates/certs/certs.yaml
+++ b/charts/plane-ce/templates/certs/certs.yaml
@@ -5,6 +5,8 @@ kind: Certificate
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ssl-cert
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   dnsNames:
   - {{ .Values.ingress.appHost | quote }}

--- a/charts/plane-ce/templates/config-secrets/app-env.yaml
+++ b/charts/plane-ce/templates/config-secrets/app-env.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-secrets
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 stringData:
   SECRET_KEY: {{ .Values.env.secret_key | default "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5" | quote }}
   LIVE_SERVER_SECRET_KEY: {{ .Values.env.live_server_secret_key | default "htbqvBJAgpm9bzvf3r4urJer0ENReatceh" | quote }}
@@ -39,6 +41,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-vars
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 data:
   SENTRY_DSN: {{ .Values.env.sentry_dsn | default "" | quote}}
   SENTRY_ENVIRONMENT: {{ .Values.env.sentry_environment | default "" | quote}}

--- a/charts/plane-ce/templates/config-secrets/doc-store.yaml
+++ b/charts/plane-ce/templates/config-secrets/doc-store.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-doc-store-secrets
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 stringData:
   FILE_SIZE_LIMIT: {{ .Values.env.doc_upload_size_limit | default 5242880 | quote }}
   AWS_S3_BUCKET_NAME: {{ .Values.env.docstore_bucket | default "" | quote  }}

--- a/charts/plane-ce/templates/config-secrets/docker-registry.yaml
+++ b/charts/plane-ce/templates/config-secrets/docker-registry.yaml
@@ -5,6 +5,8 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-docker-registry-credentials
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 data:
   .dockerconfigjson: {{ include "imagePullSecret" .}}
 type: kubernetes.io/dockerconfigjson

--- a/charts/plane-ce/templates/config-secrets/live-env.yaml
+++ b/charts/plane-ce/templates/config-secrets/live-env.yaml
@@ -5,6 +5,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-secrets
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 stringData:
   LIVE_SERVER_SECRET_KEY: {{ .Values.env.live_server_secret_key | default "htbqvBJAgpm9bzvf3r4urJer0ENReatceh" | quote }}
   {{- if .Values.redis.local_setup }}
@@ -20,6 +22,8 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-vars
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 data:
   API_BASE_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/"
   LIVE_BASE_PATH: "/live"

--- a/charts/plane-ce/templates/config-secrets/pgdb.yaml
+++ b/charts/plane-ce/templates/config-secrets/pgdb.yaml
@@ -6,6 +6,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-secrets
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 stringData:
   POSTGRES_PASSWORD: {{ .Values.env.pgdb_password | default "plane" | quote }}
   POSTGRES_DB: {{ .Values.env.pgdb_name | default "plane" | quote }}

--- a/charts/plane-ce/templates/config-secrets/rabbitmqdb.yaml
+++ b/charts/plane-ce/templates/config-secrets/rabbitmqdb.yaml
@@ -6,6 +6,8 @@ type: Opaque
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq-secrets
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 stringData:
   RABBITMQ_DEFAULT_USER: {{ .Values.rabbitmq.default_user | default "plane" | quote }}
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | default "plane" |quote }}

--- a/charts/plane-ce/templates/ingress-traefik.yaml
+++ b/charts/plane-ce/templates/ingress-traefik.yaml
@@ -4,6 +4,8 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-ingress
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 spec:
   entryPoints:
@@ -83,6 +85,8 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-minio-ingress
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 spec:
   entryPoints:
@@ -105,6 +109,8 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-rabbitmq-ingress
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 spec:
   entryPoints:

--- a/charts/plane-ce/templates/ingress.yaml
+++ b/charts/plane-ce/templates/ingress.yaml
@@ -5,6 +5,8 @@ kind: Ingress
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ingress
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
   {{- if gt (len .Values.ingress.ingress_annotations) 0 }}
   annotations:
     {{- range $key, $value := .Values.ingress.ingress_annotations }}

--- a/charts/plane-ce/templates/service-account.yaml
+++ b/charts/plane-ce/templates/service-account.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-srv-account
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 {{- if .Values.dockerRegistry.enabled }}
 imagePullSecrets:
   - name: {{ .Release.Name }}-docker-registry-credentials

--- a/charts/plane-ce/templates/traefik-middleware.yaml
+++ b/charts/plane-ce/templates/traefik-middleware.yaml
@@ -3,6 +3,8 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ .Release.Name }}-body-limit
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 spec:
   buffering:

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-admin
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.admin.assign_cluster_ip }}
   clusterIP: None
@@ -25,7 +26,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-admin-wl
-  {{- template "plane.labelsAndAnnotations" .Values.admin }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.admin) }}
 spec:
   replicas: {{ .Values.admin.replicas | default 1 }}
   selector:
@@ -36,6 +37,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-api
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.api.assign_cluster_ip }}
   clusterIP: None
@@ -25,7 +26,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-wl
-  {{- template "plane.labelsAndAnnotations" .Values.api }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
 spec:
   replicas: {{ .Values.api.replicas | default 1}}
   selector:
@@ -36,6 +37,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-beat-worker-wl
-  {{- template "plane.labelsAndAnnotations" .Values.beatworker }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.beatworker) }}
 spec:
   replicas: {{ .Values.beatworker.replicas | default 1 }}
   selector:
@@ -14,6 +14,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-live
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.live.assign_cluster_ip }}
   clusterIP: None
@@ -25,7 +26,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-wl
-  {{- template "plane.labelsAndAnnotations" .Values.live }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.live) }}
 spec:
   replicas: {{ .Values.live.replicas | default 1 }}
   selector:
@@ -36,6 +37,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-ce/templates/workloads/migrator.job.yaml
+++ b/charts/plane-ce/templates/workloads/migrator.job.yaml
@@ -4,13 +4,14 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-migrate-{{ .Release.Revision }}
-  {{- template "plane.labelsAndAnnotations" .Values.api }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
 spec:
   backoffLimit: 3
   template:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-minio
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.minio.assign_cluster_ip }}
   clusterIP: None
@@ -29,7 +30,7 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-wl
-  {{- template "plane.labelsAndAnnotations" .Values.minio }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.minio) }}
 spec:
   selector:
     matchLabels:
@@ -39,6 +40,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
+        {{- include "plane.commonLabels" $ | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.minio.image }}
@@ -86,7 +88,7 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-bucket-{{ .Release.Revision }}
-  {{- template "plane.labelsAndAnnotations" .Values.minio }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.minio) }}
 spec:
   backoffLimit: 6
   completionMode: NonIndexed

--- a/charts/plane-ce/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/postgres.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-pgdb
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.postgres.assign_cluster_ip }}
   clusterIP: None
@@ -25,7 +26,7 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-wl
-  {{- template "plane.labelsAndAnnotations" .Values.postgres }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.postgres) }}
 spec:
   selector:
     matchLabels:
@@ -35,6 +36,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
+        {{- include "plane.commonLabels" $ | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.postgres.image }}

--- a/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-rabbitmq
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.rabbitmq.assign_cluster_ip }}
   clusterIP: None
@@ -29,7 +30,7 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq-wl
-  {{- template "plane.labelsAndAnnotations" .Values.rabbitmq }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.rabbitmq) }}
 spec:
   selector:
     matchLabels:
@@ -39,6 +40,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
+        {{- include "plane.commonLabels" $ | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.rabbitmq.image }}

--- a/charts/plane-ce/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/redis.stateful.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ .Release.Name }}-redis
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.redis.assign_cluster_ip }}
   clusterIP: None
@@ -27,7 +28,7 @@ kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-redis-wl
-  {{- template "plane.labelsAndAnnotations" .Values.redis }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.redis) }}
 spec:
   selector:
     matchLabels:
@@ -37,6 +38,7 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
+        {{- include "plane.commonLabels" $ | nindent 8 }}
     spec:
       containers:
       - image: {{ .Values.redis.image }}

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-space
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.space.assign_cluster_ip }}
   clusterIP: None
@@ -25,7 +26,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-space-wl
-  {{- template "plane.labelsAndAnnotations" .Values.space }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.space) }}
 spec:
   replicas: {{ .Values.space.replicas | default 1 }}
   selector:
@@ -36,6 +37,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-web
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
+    {{- include "plane.commonLabels" $ | nindent 4 }}
 spec:
   {{- if not .Values.web.assign_cluster_ip }}
   clusterIP: None
@@ -25,7 +26,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-web-wl
-  {{- template "plane.labelsAndAnnotations" .Values.web }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.web) }}
 spec:
   replicas: {{ .Values.web.replicas | default 1 }}
   selector:
@@ -36,6 +37,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-worker-wl
-  {{- template "plane.labelsAndAnnotations" .Values.worker }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.worker) }}
 spec:
   replicas: {{ .Values.worker.replicas | default 1 }}
   selector:
@@ -14,6 +14,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
+        {{- include "plane.commonLabels" $ | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
     spec:


### PR DESCRIPTION
## What

Adds the standard Kubernetes/Helm [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) to every `plane-ce` resource and pod template:

```yaml
labels:
  helm.sh/chart: plane-ce-1.6.0
  app.kubernetes.io/name: plane-ce
  app.kubernetes.io/instance: <release>
  app.kubernetes.io/managed-by: Helm
  app.kubernetes.io/version: "1.3.1"
```

Centralized in `_helpers.tpl` via `plane.chart` + `plane.commonLabels`, with `plane.labelsAndAnnotations` refactored to always emit them and still merge per-component labels/annotations.

## Why

Resolves #135 for the community chart. Resources previously carried only a custom `app.name` label — none of the standard `app.kubernetes.io/*` / `helm.sh/chart` labels tooling relies on (`kubectl -l app.kubernetes.io/instance=...`, ArgoCD/Flux ownership, inventory dashboards).

## Scope

- **Community split of #256** (which covered both charts) — this PR is `plane-ce` only; the `plane-enterprise` half stays in #256.
- **Purely additive & upgrade-safe:** `spec.selector` / `matchLabels` and the existing `app.name` label are unchanged, so `helm upgrade` never mutates an immutable selector.
- Bumps `plane-ce` chart `1.5.1 → 1.6.0`.

## Testing

- `helm lint charts/plane-ce` — 0 failures.
- `helm template` before/after diff: only standard-label lines added; **zero** removals/modifications to selectors or existing content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Plane CE Helm chart to version 1.6.0.
  * Implemented standardized labeling across all deployed Kubernetes resources (Secrets, ConfigMaps, Services, Ingress, and workloads) to improve resource organization and cluster management visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->