### PR TITLE
[INFRA-437] - feat(plane-enterprise): configurable labels & annotations for all resources, pods, and one-shot jobs

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 2.7.0
+version: 2.8.0
 appVersion: "2.6.3"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -258,6 +258,50 @@ securityContext:
     runAsUser: 10001
 ```
 
+### Labels and Annotations
+
+The chart always applies the standard Kubernetes recommended labels (`app.kubernetes.io/name`,
+`app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/version` and
+`helm.sh/chart`) to every resource. On top of those you can attach your own labels/annotations at
+three scopes. All scopes are merged and **more specific scopes win on key conflicts**. The chart's
+`app.name` selector label is never overridden, and nothing is ever injected into a
+`selector`/`matchLabels`, so `helm upgrade` of an existing release is always safe.
+
+| Setting                          | Default | Required | Scope                    | Description                                                                                                                                                                                                                             |
+| -------------------------------- | :-----: | :------: | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| commonLabels                     |  `{}`   |    No    | **Every resource**       | Labels added to the metadata of **every object** the chart creates (Deployments, StatefulSets, Jobs, Services, ConfigMaps, Secrets, certs, Ingress/IngressRoute, ServiceAccount, Middleware) **and** to every pod template.            |
+| commonAnnotations                |  `{}`   |    No    | **Every resource**       | Annotations added to every object's metadata and every pod template. On the nginx `Ingress` these merge with `ingress.ingress_annotations` (the ingress-specific value wins).                                                          |
+| services.\<svc\>.labels          |  `{}`   |    No    | One workload **object**  | Labels added to a single workload's own resource metadata (the Deployment/StatefulSet/Job object). Wins over `commonLabels`.                                                                                                           |
+| services.\<svc\>.annotations     |  `{}`   |    No    | One workload **object**  | Annotations added to a single workload's own resource metadata. Wins over `commonAnnotations`.                                                                                                                                        |
+| services.\<svc\>.podLabels       |  `{}`   |    No    | One workload **pods**    | Labels added to a single workload's pod template only (e.g. `services.api.podLabels`). Wins over `commonLabels`. This is what service meshes, NetworkPolicies and Prometheus pod selectors match on.                                   |
+| services.\<svc\>.podAnnotations  |  `{}`   |    No    | One workload **pods**    | Annotations added to a single workload's pod template only (e.g. `services.api.podAnnotations`). Wins over `commonAnnotations`.                                                                                                        |
+| services.api.migrator.\*         |  `{}`   |    No    | Migration **Job** only   | `labels`/`annotations`/`podLabels`/`podAnnotations` for the one-shot db-migration Job. The Job inherits all of `services.api`'s maps; keys set here **win** on conflict — e.g. `podAnnotations: {sidecar.istio.io/inject: "false"}` so the Job can complete on a meshed cluster, or `annotations: {argocd.argoproj.io/hook: PreSync}`. |
+| services.pi.migrator.\*          |  `{}`   |    No    | pi migration **Job** only  | Same override tier for the pi db-migration Job (inherits `services.pi`'s maps).                                                                                                                                                     |
+| services.minio.bucketJob.\*      |  `{}`   |    No    | Bucket-setup **Job** only  | Same override tier for the MinIO bucket-setup Job (inherits `services.minio`'s maps).                                                                                                                                               |
+
+> **Object-level vs pod-level.** `services.<svc>.labels`/`annotations` land on the **workload
+> resource** (the Deployment/StatefulSet object itself). `services.<svc>.podLabels`/`podAnnotations`
+> land on the **pod template** (`spec.template.metadata`), so they propagate to every pod.
+> `commonLabels`/`commonAnnotations` reach **both** levels, on every object in the chart.
+> One-shot Jobs (api/pi migrators, MinIO bucket setup) inherit their parent service's maps and can
+> selectively override them via the `migrator`/`bucketJob` blocks — precedence is
+> `job override` > `services.<svc>.*` > `common*` > standard labels.
+
+```yaml
+commonLabels:
+  team: platform
+commonAnnotations:
+  cost-center: engineering
+services:
+  api:
+    labels: {}          # only the api Deployment/Service object
+    annotations: {}
+    podLabels:          # only the api pods; wins over commonLabels
+      tier: backend
+    podAnnotations:
+      prometheus.io/scrape: "true"
+```
+
 ### Docker Registry
 
 | Setting                      | Default              | Required | Description                                                                                                                                                                                                                                                                                                                        |

--- a/charts/plane-enterprise/templates/_helpers.tpl
+++ b/charts/plane-enterprise/templates/_helpers.tpl
@@ -54,9 +54,9 @@ Standard Kubernetes recommended labels shared by every resource the chart render
 These are additive metadata labels only; they are intentionally kept out of
 spec.selector/matchLabels (which stay on the immutable `app.name` label) so that
 upgrading an existing release never tries to mutate an immutable selector.
-Call with the root context, e.g. {{ include "plane.commonLabels" $ }}
+Call with the root context, e.g. {{ include "plane.standardLabels" $ }}
 */}}
-{{- define "plane.commonLabels" -}}
+{{- define "plane.standardLabels" -}}
 helm.sh/chart: {{ include "plane.chart" . }}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
@@ -67,23 +67,92 @@ app.kubernetes.io/version: {{ . | quote }}
 {{- end -}}
 
 {{/*
-Render a resource's `labels` and `annotations` metadata.
-Always emits the standard recommended labels (see plane.commonLabels) and merges
-any per-component labels supplied under the component's `labels` value. Per-component
-annotations are emitted when present.
+Object-metadata labels as a bare map (no `labels:` key): the standard recommended
+labels merged with the chart-wide user map `.Values.commonLabels`. The user map wins
+on key conflicts. Always non-empty (the standard labels are always present), so callers
+append it under a `labels:` key without a `with` guard. Call with the root context.
+  labels:
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+*/}}
+{{- define "plane.resourceLabels" -}}
+{{- $std := fromYaml (include "plane.standardLabels" .) -}}
+{{- toYaml (merge (dict) (.Values.commonLabels | default dict) $std) -}}
+{{- end -}}
+
+{{/*
+Object-metadata annotations as a bare map (no `annotations:` key): the chart-wide user
+map `.Values.commonAnnotations`. May be empty, so callers guard it with `with` and only
+then emit the `annotations:` key. Call with the root context.
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+*/}}
+{{- define "plane.resourceAnnotations" -}}
+{{- with .Values.commonAnnotations }}{{ toYaml . }}{{- end }}
+{{- end -}}
+
+{{/*
+Render a resource's `labels` and `annotations` metadata block. Emits the standard
+recommended labels + the chart-wide `.Values.commonLabels` + the per-component `labels`
+map, all merged into a single block (per-component wins over commonLabels wins over the
+standard labels, so no duplicate keys). Annotations merge `.Values.commonAnnotations`
+with the per-component `annotations` map (per-component wins) and are emitted only when
+non-empty. Never touches spec.selector/matchLabels.
 Call with a dict carrying the root context and the component values:
   {{ include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.api) }}
+One-shot Jobs that inherit a parent service's values may pass an optional job-override
+map whose labels/annotations win over the parent's (e.g. an ArgoCD hook annotation that
+belongs on the migration Job but not on the api Deployment):
+  {{ include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.api "job" .Values.services.api.migrator) }}
 */}}
-{{- define "plane.labelsAndAnnotations" }}
-  labels:
-    {{- include "plane.commonLabels" .context | nindent 4 }}
-    {{- with .values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with .values.annotations }}
+{{- define "plane.labelsAndAnnotations" -}}
+{{- $std := fromYaml (include "plane.standardLabels" .context) -}}
+{{- $job := .job | default dict -}}
+{{- $labels := merge (dict) ($job.labels | default dict) (.values.labels | default dict) (.context.Values.commonLabels | default dict) $std -}}
+{{- $annotations := merge (dict) ($job.annotations | default dict) (.values.annotations | default dict) (.context.Values.commonAnnotations | default dict) }}
+  labels: {{ toYaml $labels | nindent 4 }}
+  {{- with $annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
+{{/*
+Pod-template labels as a bare map (no `labels:` key): the standard recommended labels +
+chart-wide `.Values.commonLabels` + the per-workload `podLabels` map, merged into one
+block (podLabels wins over commonLabels wins over the standard labels). Always non-empty,
+so callers append it under the pod template's `labels:` key (which already carries the
+static `app.name` selector label) without a `with` guard. The `app.name` label is emitted
+by the template itself and never included here, so the selector is never duplicated.
+Call with a dict carrying the root context and the component values:
+  labels:
+    app.name: ...
+    {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.api) | nindent 8 }}
+*/}}
+{{- define "plane.podLabels" -}}
+{{- $ctx := .context -}}
+{{- $values := .values | default dict -}}
+{{- $job := .job | default dict -}}
+{{- $std := fromYaml (include "plane.standardLabels" $ctx) -}}
+{{- toYaml (merge (dict) ($job.podLabels | default dict) ($values.podLabels | default dict) ($ctx.Values.commonLabels | default dict) $std) -}}
+{{- end -}}
+
+{{/*
+Pod-template annotations as a bare map (no `annotations:` key): the chart-wide
+`.Values.commonAnnotations` merged with the per-workload `podAnnotations` map
+(podAnnotations wins). May be empty, so callers guard it with `with`.
+Call with a dict carrying the root context and the component values:
+  {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.api)) }}
+  {{- . | nindent 8 }}
+  {{- end }}
+*/}}
+{{- define "plane.podAnnotations" -}}
+{{- $ctx := .context -}}
+{{- $values := .values | default dict -}}
+{{- $job := .job | default dict -}}
+{{- $merged := merge (dict) ($job.podAnnotations | default dict) ($values.podAnnotations | default dict) ($ctx.Values.commonAnnotations | default dict) -}}
+{{- with $merged }}{{ toYaml . }}{{- end }}
+{{- end -}}
 
 {{/*
 Returns "true" when the bundled MinIO should be deployed.

--- a/charts/plane-enterprise/templates/certs/cert-issuers.yaml
+++ b/charts/plane-enterprise/templates/certs/cert-issuers.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-issuer-api-token-secret
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
   api-token: {{ .Values.ssl.token | default "default-api-token" | quote }}
@@ -18,7 +22,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-cert-issuer
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   acme:
     email: {{ .Values.ssl.email }}

--- a/charts/plane-enterprise/templates/certs/certs.yaml
+++ b/charts/plane-enterprise/templates/certs/certs.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ssl-cert
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   dnsNames:
   - {{ .Values.license.licenseDomain | quote }}

--- a/charts/plane-enterprise/templates/certs/email-certs.yaml
+++ b/charts/plane-enterprise/templates/certs/email-certs.yaml
@@ -4,7 +4,11 @@ kind: Certificate
 metadata:
   name: {{ .Release.Name }}-mail-tls-cert
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -9,7 +9,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   SECRET_KEY: {{ .Values.env.secret_key | default "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5" | quote }}
   AES_SECRET_KEY: {{ .Values.env.silo_envs.aes_secret_key | default "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr" | quote }}
@@ -54,7 +58,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   PRIME_HOST: {{ .Values.license.licenseServer | quote }}
   MACHINE_SIGNATURE: {{ include "hashString" . | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/automations-consumer.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/automations-consumer.yaml
@@ -5,7 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-automation-consumer-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   AUTOMATION_EVENT_STREAM_QUEUE_NAME: {{ .Values.env.automation_consumer_envs.event_stream_queue_name | default "plane.event_stream.automations" | quote }}
   AUTOMATION_EVENT_STREAM_PREFETCH: {{ .Values.env.automation_consumer_envs.event_stream_prefetch | default 10 | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/doc-store.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/doc-store.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-doc-store-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   FILE_SIZE_LIMIT: {{ .Values.env.doc_upload_size_limit | default "20971520" | quote }}
   AWS_S3_BUCKET_NAME: {{ .Values.env.docstore_bucket | default "" | quote  }}

--- a/charts/plane-enterprise/templates/config-secrets/docker-registry.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/docker-registry.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-docker-registry-credentials
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   .dockerconfigjson: {{ include "imagePullSecret" .}}
 type: kubernetes.io/dockerconfigjson

--- a/charts/plane-enterprise/templates/config-secrets/email-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/email-env.yaml
@@ -5,7 +5,11 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-email-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 data:
   SMTP_DOMAIN: {{ .Values.env.email_service_envs.smtp_domain | default "" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/live-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/live-env.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   LIVE_SERVER_SECRET_KEY: {{ .Values.env.live_server_secret_key | default "htbqvBJAgpm9bzvf3r4urJer0ENReatceh" | quote }}
   {{- if .Values.services.redis.local_setup }}
@@ -22,7 +26,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   API_BASE_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}:8000/"
   LIVE_SENTRY_DSN: {{ .Values.env.live_sentry_dsn | default "" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/monitor.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/monitor.yaml
@@ -4,7 +4,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-monitor-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   PRIME_HOST: {{ .Values.license.licenseServer | quote }}
   MACHINE_SIGNATURE: {{ include "hashString" . | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/opensearchdb.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/opensearchdb.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-opensearch-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   {{- if .Values.services.opensearch.local_setup }}
   OPENSEARCH_ENABLED: "1"
@@ -40,7 +44,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-opensearch-init
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   create-user.sh: |
     #!/bin/bash

--- a/charts/plane-enterprise/templates/config-secrets/outbox-poller.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/outbox-poller.yaml
@@ -5,7 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-outbox-poller-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   OUTBOX_POLLER_MEMORY_LIMIT_MB: {{ .Values.env.outbox_poller_envs.memory_limit_mb | default 400 | quote }}
   OUTBOX_POLLER_INTERVAL_MIN: {{ .Values.env.outbox_poller_envs.interval_min | default 0.25 | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/pgdb.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/pgdb.yaml
@@ -8,7 +8,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   POSTGRES_USER: {{ .Values.env.pgdb_username | default "plane" | quote }}
   POSTGRES_PASSWORD: {{ .Values.env.pgdb_password | default "plane" | quote }}
@@ -22,7 +26,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   POSTGRES_USER: {{ .Values.env.pgdb_username | default "plane" | quote }}
   init-dbs.sql: |

--- a/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
@@ -7,7 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pi-api-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   {{- if .Values.services.postgres.local_setup }}
   PLANE_PI_DATABASE_URL: "postgresql://{{ .Values.env.pgdb_username }}:{{ .Values.env.pgdb_password }}@{{ .Release.Name }}-pgdb.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}/{{ .Values.env.pg_pi_db_name }}"
@@ -84,7 +88,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pi-api-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   DEBUG: {{ if .Values.env.pi_envs.debug | default false }} "1" {{- else -}} "0" {{ end }}
   LOG_LEVEL: {{ .Values.env.pi_envs.log_level | default "DEBUG" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/rabbitmqdb.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/rabbitmqdb.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   RABBITMQ_DEFAULT_USER: {{ .Values.services.rabbitmq.default_user | default "plane" | quote }}
   RABBITMQ_DEFAULT_PASS: {{ .Values.services.rabbitmq.default_password | default "plane" |quote }}

--- a/charts/plane-enterprise/templates/config-secrets/runner-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/runner-env.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-runner-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   RUNNER_HMAC_SECRET_KEY: {{ .Values.env.runner_envs.hmac_secret_key | default "" | quote }}
 {{- end }}
@@ -18,7 +22,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-runner-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   NODE_ENV: "production"
   PORT: "3000"

--- a/charts/plane-enterprise/templates/config-secrets/silo.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/silo.yaml
@@ -7,7 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-silo-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   SILO_HMAC_SECRET_KEY: {{ .Values.env.silo_envs.hmac_secret_key | default "gzb7MRLr0FoN129NyWARZEs84P9LzQ" | quote }}
   AES_SECRET_KEY: {{ .Values.env.silo_envs.aes_secret_key | default "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr" | quote }}
@@ -64,7 +68,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-silo-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   PORT: "3000"
   BATCH_SIZE: {{ .Values.env.silo_envs.batch_size | default 100 | quote }}

--- a/charts/plane-enterprise/templates/ingress-traefik.yaml
+++ b/charts/plane-enterprise/templates/ingress-traefik.yaml
@@ -5,7 +5,11 @@ kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-ingress
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   entryPoints:

--- a/charts/plane-enterprise/templates/ingress.yaml
+++ b/charts/plane-enterprise/templates/ingress.yaml
@@ -6,12 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ingress
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
-  {{- if gt (len .Values.ingress.ingress_annotations) 0 }}
-  annotations:
-    {{- range $key, $value := .Values.ingress.ingress_annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- $annotations := merge (dict) (.Values.ingress.ingress_annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClass }}

--- a/charts/plane-enterprise/templates/service-account.yaml
+++ b/charts/plane-enterprise/templates/service-account.yaml
@@ -5,7 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-srv-account
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 {{- if .Values.dockerRegistry.enabled }}
 imagePullSecrets:
 {{- if .Values.dockerRegistry.existingSecret }}

--- a/charts/plane-enterprise/templates/traefik-middleware.yaml
+++ b/charts/plane-enterprise/templates/traefik-middleware.yaml
@@ -4,10 +4,15 @@ kind: Middleware
 metadata:
   name: {{ .Release.Name }}-body-limit
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   buffering:
-    maxRequestBodyBytes: {{ .Values.ingress.traefik.maxRequestBodyBytes | default 20971520 }}
+    {{- /* int64 keeps Helm's float64 YAML numbers from rendering as scientific notation (e.g. 2.097152e+07), which the Traefik CRD's integer field can reject */}}
+    maxRequestBodyBytes: {{ .Values.ingress.traefik.maxRequestBodyBytes | default 20971520 | int64 }}
 
 {{- end }}

--- a/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/admin.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-admin
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.admin.assign_cluster_ip }}
@@ -38,9 +42,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.admin) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.admin)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.admin }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/api.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-api
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.api.assign_cluster_ip }}
@@ -38,9 +42,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.api) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.api)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.api }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/automation-consumer.deployment.yaml
@@ -15,9 +15,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-automation-consumer
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.automation_consumer) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.automation_consumer)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.automation_consumer }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/beat-worker.deployment.yaml
@@ -14,9 +14,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.beatworker) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.beatworker)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.beatworker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/email.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/email.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-email-service
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local  # Important for email servers
@@ -45,9 +49,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-email-app
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.email_service) | nindent 8 }}
       annotations:  
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.email_service)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.email_service }}
       containers:

--- a/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/iframely.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-iframely
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-iframely
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   ports:
@@ -35,9 +39,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-iframely
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.iframely) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.iframely)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.iframely }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/live.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/live.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-live
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.live.assign_cluster_ip }}
@@ -38,9 +42,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.live) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.live)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.live }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/migrator.job.yaml
@@ -4,16 +4,19 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-migrate-{{ now | date "20060102-150405" }}
-  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.api) }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.api "job" .Values.services.api.migrator) }}
 spec:
   backoffLimit: 3
   template:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.api "job" .Values.services.api.migrator) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.api "job" .Values.services.api.migrator)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.api }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-minio
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.minio.assign_cluster_ip }}
@@ -40,7 +44,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.minio) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.minio)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.minio }}
       containers:
@@ -88,13 +96,19 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-bucket-{{ now | date "20060102-150405" }}
-  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.minio) }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.minio "job" .Values.services.minio.bucketJob) }}
 spec:
   backoffLimit: 6
   completionMode: NonIndexed
   template:
     metadata:
       namespace: {{ .Release.Namespace }}
+      labels:
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.minio "job" .Values.services.minio.bucketJob) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.minio "job" .Values.services.minio.bucketJob)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.minio }}
       restartPolicy: OnFailure

--- a/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/monitor.stateful.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ .Release.Name }}-monitor
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-monitor
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.monitor.assign_cluster_ip }}
@@ -35,9 +39,12 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-monitor
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.monitor) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.monitor)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.monitor }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/opensearch.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/opensearch.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-opensearch
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-opensearch
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.opensearch.assign_cluster_ip }}
@@ -36,7 +40,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-opensearch
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.opensearch) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.opensearch)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.opensearch }}
       securityContext:

--- a/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/outbox-poller.deployment.yaml
@@ -15,9 +15,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-outbox-poller
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.outbox_poller) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.outbox_poller)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.outbox_poller }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-api.deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-pi-api
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-api
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.pi.assign_cluster_ip }}
@@ -39,9 +43,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-api
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.pi) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.pi)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-beat.deployment.yaml
@@ -15,9 +15,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-beat
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.pi_beat_worker) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.pi_beat_worker)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi_beat_worker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-migrator.job.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-migrator.job.yaml
@@ -5,17 +5,19 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pi-api-migrate-{{ now | date "20060102-150405" }}
-  labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.pi "job" .Values.services.pi.migrator) }}
 spec:
   backoffLimit: 3
   template:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-api-migrate
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.pi "job" .Values.services.pi.migrator) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.pi "job" .Values.services.pi.migrator)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/pi-worker.deployment.yaml
@@ -15,9 +15,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pi-worker
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.pi_worker) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.pi_worker)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.pi_worker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/postgres.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-pgdb
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.postgres.assign_cluster_ip }}
@@ -36,7 +40,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.postgres) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.postgres)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.postgres }}
       containers:

--- a/charts/plane-enterprise/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/rabbitmq.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-rabbitmq
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.rabbitmq.assign_cluster_ip }}
@@ -40,7 +44,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.rabbitmq) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.rabbitmq)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.rabbitmq }}
       containers:

--- a/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/redis.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-redis
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.redis.assign_cluster_ip }}
@@ -39,7 +43,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.redis) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.redis)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.redis }}
       containers:

--- a/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/runner.deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-runner
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-runner
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.runner.assign_cluster_ip }}
@@ -39,9 +43,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-runner
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.runner) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.runner)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.runner }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/silo.deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-silo
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.silo.assign_cluster_ip }}
@@ -39,9 +43,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-silo
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.silo) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.silo)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.silo }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/space.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/space.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-space
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.space.assign_cluster_ip }}
@@ -38,9 +42,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.space) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.space)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.space }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/web.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/web.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-web
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   {{- if not .Values.services.web.assign_cluster_ip }}
@@ -38,9 +42,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.web) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.web)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.web }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/worker.deployment.yaml
@@ -14,9 +14,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.services.worker) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.services.worker)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "plane.podScheduling" .Values.services.worker }}
       {{- include "plane.podSecurityContext" . }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,5 +1,23 @@
 planeVersion: v2.6.3
 
+# Chart-wide labels/annotations added to the metadata of EVERY resource the chart
+# creates (Deployments, StatefulSets, Jobs, Services, ConfigMaps, Secrets, certs,
+# Ingress/IngressRoute, ServiceAccount, Middleware, ...) AND to every pod template.
+# Useful for cost-allocation, ownership, NetworkPolicy/service-mesh targeting,
+# Prometheus scrape hints, external-dns, etc. These are additive and never override
+# the chart's standard recommended labels (app.kubernetes.io/*, helm.sh/chart) unless
+# you set the same key, and are never injected into a selector/matchLabels.
+# For a narrower scope, use:
+#   - services.<svc>.labels / annotations       -> that workload's OBJECT only
+#   - services.<svc>.podLabels / podAnnotations -> that workload's PODS only
+# Per-service maps win over these chart-wide values on key conflicts.
+#   commonLabels:
+#     team: platform
+#   commonAnnotations:
+#     cost-center: engineering
+commonLabels: {}
+commonAnnotations: {}
+
 dockerRegistry:
   enabled: false
   registry: 'index.docker.io/v1/'
@@ -112,6 +130,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   postgres:
     local_setup: true
@@ -125,6 +145,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
     read_replica:
       enabled: false
       remote_url: '' # INCASE OF REMOTE PG DB URL ONLY
@@ -145,6 +167,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   opensearch:
     local_setup: false
@@ -164,6 +188,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   minio:
     local_setup: true
@@ -181,6 +207,15 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
+    # Extra metadata for the one-shot bucket-setup Job ONLY (inherits minio's maps
+    # above; keys here win on conflict). See services.api.migrator for typical uses.
+    bucketJob:
+      labels: {}
+      annotations: {}
+      podLabels: {}
+      podAnnotations: {}
 
   iframely:
     enabled: false
@@ -197,6 +232,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   web:
     replicas: 1
@@ -212,6 +249,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   monitor:
     memoryLimit: 1000Mi
@@ -227,6 +266,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   space:
     replicas: 1
@@ -242,6 +283,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   admin:
     replicas: 1
@@ -257,6 +300,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   live:
     replicas: 1
@@ -272,6 +317,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   api:
     replicas: 1
@@ -287,6 +334,18 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
+    # Extra metadata for the one-shot db-migration Job ONLY. The Job inherits all of
+    # api's labels/annotations/podLabels/podAnnotations above; keys set here WIN over
+    # the inherited ones on conflict. Typical uses: turn OFF service-mesh sidecar
+    # injection so the Job can complete (sidecar.istio.io/inject: "false"), Vault
+    # agent-pre-populate-only, or GitOps hook annotations (argocd.argoproj.io/hook).
+    migrator:
+      labels: {}
+      annotations: {}
+      podLabels: {}
+      podAnnotations: {}
 
   worker:
     replicas: 1
@@ -299,6 +358,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   beatworker:
     replicas: 1
@@ -311,6 +372,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   silo:
     enabled: true
@@ -327,6 +390,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
     connectors:
       slack:
         enabled: false
@@ -364,6 +429,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   outbox_poller:
     enabled: false
@@ -379,6 +446,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   automation_consumer:
     enabled: false
@@ -394,6 +463,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   pi:
     enabled: false
@@ -410,6 +481,15 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
+    # Extra metadata for the one-shot pi db-migration Job ONLY (inherits pi's maps
+    # above; keys here win on conflict). See services.api.migrator for typical uses.
+    migrator:
+      labels: {}
+      annotations: {}
+      podLabels: {}
+      podAnnotations: {}
     ai_providers:
       openai:
         enabled: false
@@ -457,6 +537,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   pi_worker:
     replicas: 1
@@ -469,6 +551,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
   runner:
     enabled: false
@@ -485,6 +569,8 @@ services:
     affinity: {}
     labels: {}
     annotations: {}
+    podLabels: {}
+    podAnnotations: {}
 
 external_secrets:
   # Name of the existing Kubernetes Secret resource; see README for more details


### PR DESCRIPTION
## What

Makes labels/annotations user-configurable across the entire `plane-enterprise` chart, layered on top of the standard recommended labels from #256. Adds to `values.yaml`:

```yaml
commonLabels: {}          # every object + every pod template
commonAnnotations: {}
services:
  <svc>:
    labels: {}            # (pre-existing) that workload's object metadata
    annotations: {}
    podLabels: {}         # NEW: that workload's pod template only
    podAnnotations: {}
  api:
    migrator:             # NEW: override tier for the one-shot migration Job
      labels: {} 
      annotations: {}
      podLabels: {}
      podAnnotations: {}
  # same override tier: services.pi.migrator, services.minio.bucketJob
```

Precedence on key conflict: **job override > per-service > common > standard labels**. All 46 chart objects (Deployments, StatefulSets, Jobs, Services, ConfigMaps, Secrets, certs, Ingress/IngressRoute, ServiceAccount, Middleware) and all 24 pod templates are wired through shared helpers in `templates/_helpers.tpl`.

## Why

- **Pod-level metadata is what runtime tooling matches on**: NetworkPolicy/Cilium `podSelector`, service-mesh injection (`sidecar.istio.io/inject`), Prometheus scrape annotations, Vault agent injection. The chart previously exposed only object-level `services.<svc>.labels`, so none of these integrations could target Plane pods.
- **Chart-wide `commonLabels`/`commonAnnotations`** (Grafana/GitLab convention) enable cost-allocation, ownership, and GitOps grouping without repeating maps per service.
- **The job override tier** solves the classic meshed-cluster failure: `sidecar.istio.io/inject: "true"` on api pods would be inherited by the migration Job, whose sidecar never exits, so the Job never completes. Jobs inherit the parent service's maps and can selectively override (`inject: "false"`), and take Job-only object annotations like `argocd.argoproj.io/hook: PreSync`.

## Scope / behavior

- **Default behavior unchanged**: all new values default to `{}`; with defaults the rendered output is identical to master except the three bug-fixes below. Verified by rendering both.
- **`helm upgrade` safe**: nothing is ever injected into `spec.selector`/`matchLabels` — selectors stay on the immutable `app.name` label. Verified selectors are byte-identical between unlabeled and fully-labeled renders (24 objects).
- The nginx `Ingress` merges `commonAnnotations` with the existing `ingress.ingress_annotations` (ingress-specific wins). Traefik `IngressRoute`/`Middleware` get the common maps too.
- Helper rename (internal only): `plane.commonLabels` (#256) → `plane.standardLabels`, freeing the "common" name for the user-facing values key (GitLab's naming); new `plane.resourceLabels`/`plane.resourceAnnotations`/`plane.podLabels`/`plane.podAnnotations` compose the tiers. Rename verified byte-identical on rendered output.

### Bug fixes (found while testing)
1. **MinIO bucket Job pod template had no labels at all** (missed in #256 as well) — now carries standard + configured labels like every other pod.
2. **pi-migrator Job object metadata skipped `services.pi.labels`** while its pods used `services.pi.podLabels` — now consistent with the api-migrator and bucket Jobs.
3. **Traefik `Middleware` rendered `maxRequestBodyBytes: 2.097152e+07`** (Helm float64 scientific notation), which the CRD's integer field can reject — now `| int64`, renders `20971520`.

## Testing

- `helm lint` clean; chart version bumped 2.7.0 → 2.8.0.
- 6-scenario render-assertion suite (~2,500 programmatic assertions via `helm template` + YAML parsing), covering:
  - defaults: standard labels on all 41 docs, zero user keys leak, no empty `labels:`/`annotations:` blocks;
  - full combo with all optional services enabled (65 docs): common maps on every object and every pod template including Jobs; per-service beats common (`services.api.labels.team` wins on the api object; `services.postgres.podLabels.team` wins on postgres pods);
  - job overrides: api pods render `sidecar.istio.io/inject: "true"` while migrator pods render `"false"` yet still inherit api's prometheus annotations; ArgoCD hook lands on the Job object only;
  - nginx ingress annotation merge conflict (`ingress_annotations` wins) and traefik IngressRoute/Middleware coverage;
  - standard-label override escape hatch (`commonLabels."app.kubernetes.io/version"` wins, documented);
  - special-character values (JSON-with-colons, unicode, URLs, numeric/boolean strings stay strings);
  - selector immutability across unlabeled vs fully-labeled renders.

## Upgrade notes

None required. Existing releases upgrade in place: selectors are untouched; new labels/annotations only appear if the operator sets the new values.

## Related

- Builds on #256 / #257 (standard recommended labels, INFRA-424/423).
- Work item: [INFRA-437]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable labels and annotations across chart resources and pod templates.
  * Expanded metadata customization for services, workloads, and one-off jobs.

* **Bug Fixes**
  * Improved metadata handling so labels and annotations are applied more consistently and only when provided.
  * Preserved required selector labels while allowing user-defined metadata overrides.

* **Chores**
  * Bumped the chart version to 2.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->