### PR TITLE
[INFRA-438] - feat(plane-ce): configurable labels & annotations for all resources, pods, and one-shot jobs

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.6.0
+version: 1.7.0
 appVersion: "1.3.1"
 
 home: https://plane.so

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -165,6 +165,48 @@ The default value is `"traefik"`. If you previously relied on the implicit defau
 | ------------ | :-----: | :------: | ----------- |
 | planeVersion | v1.3.1  |   Yes    |             |
 
+### Labels and Annotations
+
+The chart always applies the standard Kubernetes recommended labels (`app.kubernetes.io/name`,
+`app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/version` and
+`helm.sh/chart`) to every resource. On top of those you can attach your own labels/annotations at
+three scopes. All scopes are merged and **more specific scopes win on key conflicts**. The chart's
+`app.name` selector label is never overridden, and nothing is ever injected into a
+`selector`/`matchLabels`, so `helm upgrade` of an existing release is always safe.
+
+| Setting                          | Default | Required | Scope                    | Description                                                                                                                                                                                            |
+| -------------------------------- | :-----: | :------: | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| commonLabels                     |  `{}`   |    No    | **Every resource**       | Labels added to the metadata of **every object** the chart creates (Deployments, StatefulSets, Jobs, Services, ConfigMaps, Secrets, certs, Ingress/IngressRoute, ServiceAccount, Middleware) **and** to every pod template. |
+| commonAnnotations                |  `{}`   |    No    | **Every resource**       | Annotations added to every object's metadata and every pod template. On the nginx `Ingress` these merge with `ingress.ingress_annotations` (the ingress-specific value wins).                          |
+| \<component\>.labels             |  `{}`   |    No    | One workload **object**  | Labels added to a single workload's own resource metadata (e.g. `api.labels`). Wins over `commonLabels`.                                                                                               |
+| \<component\>.annotations        |  `{}`   |    No    | One workload **object**  | Annotations added to a single workload's own resource metadata. Wins over `commonAnnotations`.                                                                                                        |
+| \<component\>.podLabels          |  `{}`   |    No    | One workload **pods**    | Labels added to a single workload's pod template only (e.g. `api.podLabels`). Wins over `commonLabels`. This is what service meshes, NetworkPolicies and Prometheus pod selectors match on.            |
+| \<component\>.podAnnotations     |  `{}`   |    No    | One workload **pods**    | Annotations added to a single workload's pod template only. Wins over `commonAnnotations`.                                                                                                            |
+| api.migrator.\*                  |  `{}`   |    No    | Migration **Job** only   | `labels`/`annotations`/`podLabels`/`podAnnotations` for the one-shot db-migration Job. The Job inherits all of `api`'s maps; keys set here **win** on conflict — e.g. `podAnnotations: {sidecar.istio.io/inject: "false"}` so the Job can complete on a meshed cluster. |
+| minio.bucketJob.\*               |  `{}`   |    No    | Bucket-setup **Job** only | Same override tier for the MinIO bucket-setup Job (inherits `minio`'s maps).                                                                                                                          |
+
+> **Object-level vs pod-level.** `<component>.labels`/`annotations` land on the **workload resource**
+> (the Deployment/StatefulSet object itself). `<component>.podLabels`/`podAnnotations` land on the
+> **pod template** (`spec.template.metadata`), so they propagate to every pod. `commonLabels`/
+> `commonAnnotations` reach **both** levels, on every object in the chart. One-shot Jobs inherit
+> their parent component and can selectively override via `api.migrator` / `minio.bucketJob` —
+> precedence is `job override` > `<component>.*` > `common*` > standard labels.
+
+```yaml
+commonLabels:
+  team: platform
+commonAnnotations:
+  cost-center: engineering
+api:
+  podLabels:
+    tier: backend
+  podAnnotations:
+    prometheus.io/scrape: "true"
+  migrator:
+    podAnnotations:
+      sidecar.istio.io/inject: "false"
+```
+
 ### Postgress DB Setup
 
 | Setting                    |              Default              | Required | Description                                                                                                                                                                                                                                                                                                                                                                             |

--- a/charts/plane-ce/templates/_helpers.tpl
+++ b/charts/plane-ce/templates/_helpers.tpl
@@ -26,9 +26,9 @@ Standard Kubernetes recommended labels shared by every resource the chart render
 These are additive metadata labels only; they are intentionally kept out of
 spec.selector/matchLabels (which stay on the immutable `app.name` label) so that
 upgrading an existing release never tries to mutate an immutable selector.
-Call with the root context, e.g. {{ include "plane.commonLabels" $ }}
+Call with the root context, e.g. {{ include "plane.standardLabels" $ }}
 */}}
-{{- define "plane.commonLabels" -}}
+{{- define "plane.standardLabels" -}}
 helm.sh/chart: {{ include "plane.chart" . }}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
@@ -39,20 +39,91 @@ app.kubernetes.io/version: {{ . | quote }}
 {{- end -}}
 
 {{/*
-Render a resource's `labels` and `annotations` metadata.
-Always emits the standard recommended labels (see plane.commonLabels) and merges
-any per-component labels supplied under the component's `labels` value. Per-component
-annotations are emitted when present.
+Object-metadata labels as a bare map (no `labels:` key): the standard recommended
+labels merged with the chart-wide user map `.Values.commonLabels`. The user map wins
+on key conflicts. Always non-empty (the standard labels are always present), so callers
+append it under a `labels:` key without a `with` guard. Call with the root context.
+  labels:
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+*/}}
+{{- define "plane.resourceLabels" -}}
+{{- $std := fromYaml (include "plane.standardLabels" .) -}}
+{{- toYaml (merge (dict) (.Values.commonLabels | default dict) $std) -}}
+{{- end -}}
+
+{{/*
+Object-metadata annotations as a bare map (no `annotations:` key): the chart-wide user
+map `.Values.commonAnnotations`. May be empty, so callers guard it with `with` and only
+then emit the `annotations:` key. Call with the root context.
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+*/}}
+{{- define "plane.resourceAnnotations" -}}
+{{- with .Values.commonAnnotations }}{{ toYaml . }}{{- end }}
+{{- end -}}
+
+{{/*
+Render a resource's `labels` and `annotations` metadata block. Emits the standard
+recommended labels + the chart-wide `.Values.commonLabels` + the per-component `labels`
+map, all merged into a single block (per-component wins over commonLabels wins over the
+standard labels, so no duplicate keys). Annotations merge `.Values.commonAnnotations`
+with the per-component `annotations` map (per-component wins) and are emitted only when
+non-empty. Never touches spec.selector/matchLabels.
 Call with a dict carrying the root context and the component values:
   {{ include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
+One-shot Jobs that inherit a parent component's values may pass an optional job-override
+map whose labels/annotations win over the parent's (e.g. an ArgoCD hook annotation that
+belongs on the migration Job but not on the api Deployment):
+  {{ include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api "job" .Values.api.migrator) }}
 */}}
-{{- define "plane.labelsAndAnnotations" }}
-  labels:
-    {{- include "plane.commonLabels" .context | nindent 4 }}
-    {{- with .values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with .values.annotations }}
+{{- define "plane.labelsAndAnnotations" -}}
+{{- $std := fromYaml (include "plane.standardLabels" .context) -}}
+{{- $job := .job | default dict -}}
+{{- $labels := merge (dict) ($job.labels | default dict) (.values.labels | default dict) (.context.Values.commonLabels | default dict) $std -}}
+{{- $annotations := merge (dict) ($job.annotations | default dict) (.values.annotations | default dict) (.context.Values.commonAnnotations | default dict) }}
+  labels: {{ toYaml $labels | nindent 4 }}
+  {{- with $annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
+{{/*
+Pod-template labels as a bare map (no `labels:` key): the standard recommended labels +
+chart-wide `.Values.commonLabels` + the per-workload `podLabels` map, merged into one
+block (podLabels wins over commonLabels wins over the standard labels). Always non-empty,
+so callers append it under the pod template's `labels:` key (which already carries the
+static `app.name` selector label) without a `with` guard. The `app.name` label is emitted
+by the template itself and never included here, so the selector is never duplicated.
+Optional "job" map adds a one-shot Job's podLabels override tier (wins over all).
+Call with a dict carrying the root context and the component values:
+  labels:
+    app.name: ...
+    {{- include "plane.podLabels" (dict "context" $ "values" .Values.api) | nindent 8 }}
+*/}}
+{{- define "plane.podLabels" -}}
+{{- $ctx := .context -}}
+{{- $values := .values | default dict -}}
+{{- $job := .job | default dict -}}
+{{- $std := fromYaml (include "plane.standardLabels" $ctx) -}}
+{{- toYaml (merge (dict) ($job.podLabels | default dict) ($values.podLabels | default dict) ($ctx.Values.commonLabels | default dict) $std) -}}
+{{- end -}}
+
+{{/*
+Pod-template annotations as a bare map (no `annotations:` key): the chart-wide
+`.Values.commonAnnotations` merged with the per-workload `podAnnotations` map
+(podAnnotations wins; an optional "job" map's podAnnotations win over both).
+May be empty, so callers guard it with `with`.
+Call with a dict carrying the root context and the component values:
+  {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.api)) }}
+  {{- . | nindent 8 }}
+  {{- end }}
+*/}}
+{{- define "plane.podAnnotations" -}}
+{{- $ctx := .context -}}
+{{- $values := .values | default dict -}}
+{{- $job := .job | default dict -}}
+{{- $merged := merge (dict) ($job.podAnnotations | default dict) ($values.podAnnotations | default dict) ($ctx.Values.commonAnnotations | default dict) -}}
+{{- with $merged }}{{ toYaml . }}{{- end }}
+{{- end -}}

--- a/charts/plane-ce/templates/certs/cert-issuers.yaml
+++ b/charts/plane-ce/templates/certs/cert-issuers.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-issuer-api-token-secret
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
   api-token: {{ .Values.ssl.token | default "default-api-token" | quote }}
@@ -18,7 +22,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-cert-issuer
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   acme:
     email: {{ .Values.ssl.email }}

--- a/charts/plane-ce/templates/certs/certs.yaml
+++ b/charts/plane-ce/templates/certs/certs.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ssl-cert
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   dnsNames:
   - {{ .Values.ingress.appHost | quote }}

--- a/charts/plane-ce/templates/config-secrets/app-env.yaml
+++ b/charts/plane-ce/templates/config-secrets/app-env.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   SECRET_KEY: {{ .Values.env.secret_key | default "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5" | quote }}
   LIVE_SERVER_SECRET_KEY: {{ .Values.env.live_server_secret_key | default "htbqvBJAgpm9bzvf3r4urJer0ENReatceh" | quote }}
@@ -42,7 +46,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-app-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   SENTRY_DSN: {{ .Values.env.sentry_dsn | default "" | quote}}
   SENTRY_ENVIRONMENT: {{ .Values.env.sentry_environment | default "" | quote}}

--- a/charts/plane-ce/templates/config-secrets/doc-store.yaml
+++ b/charts/plane-ce/templates/config-secrets/doc-store.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-doc-store-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   FILE_SIZE_LIMIT: {{ .Values.env.doc_upload_size_limit | default 5242880 | quote }}
   AWS_S3_BUCKET_NAME: {{ .Values.env.docstore_bucket | default "" | quote  }}

--- a/charts/plane-ce/templates/config-secrets/docker-registry.yaml
+++ b/charts/plane-ce/templates/config-secrets/docker-registry.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-docker-registry-credentials
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   .dockerconfigjson: {{ include "imagePullSecret" .}}
 type: kubernetes.io/dockerconfigjson

--- a/charts/plane-ce/templates/config-secrets/live-env.yaml
+++ b/charts/plane-ce/templates/config-secrets/live-env.yaml
@@ -6,7 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   LIVE_SERVER_SECRET_KEY: {{ .Values.env.live_server_secret_key | default "htbqvBJAgpm9bzvf3r4urJer0ENReatceh" | quote }}
   {{- if .Values.redis.local_setup }}
@@ -23,7 +27,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-vars
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   API_BASE_URL: "http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local:8000/"
   LIVE_BASE_PATH: "/live"

--- a/charts/plane-ce/templates/config-secrets/pgdb.yaml
+++ b/charts/plane-ce/templates/config-secrets/pgdb.yaml
@@ -7,7 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   POSTGRES_PASSWORD: {{ .Values.env.pgdb_password | default "plane" | quote }}
   POSTGRES_DB: {{ .Values.env.pgdb_name | default "plane" | quote }}

--- a/charts/plane-ce/templates/config-secrets/rabbitmqdb.yaml
+++ b/charts/plane-ce/templates/config-secrets/rabbitmqdb.yaml
@@ -7,7 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq-secrets
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 stringData:
   RABBITMQ_DEFAULT_USER: {{ .Values.rabbitmq.default_user | default "plane" | quote }}
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | default "plane" |quote }}

--- a/charts/plane-ce/templates/ingress-traefik.yaml
+++ b/charts/plane-ce/templates/ingress-traefik.yaml
@@ -5,7 +5,11 @@ kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-ingress
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   entryPoints:
@@ -86,7 +90,11 @@ kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-minio-ingress
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   entryPoints:
@@ -110,7 +118,11 @@ kind: IngressRoute
 metadata:
   name: {{ .Release.Name }}-rabbitmq-ingress
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   entryPoints:

--- a/charts/plane-ce/templates/ingress.yaml
+++ b/charts/plane-ce/templates/ingress.yaml
@@ -6,12 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-ingress
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
-  {{- if gt (len .Values.ingress.ingress_annotations) 0 }}
-  annotations:
-    {{- range $key, $value := .Values.ingress.ingress_annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- $annotations := merge (dict) (.Values.ingress.ingress_annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClass | quote }}

--- a/charts/plane-ce/templates/service-account.yaml
+++ b/charts/plane-ce/templates/service-account.yaml
@@ -5,7 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-srv-account
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 {{- if .Values.dockerRegistry.enabled }}
 imagePullSecrets:
   - name: {{ .Release.Name }}-docker-registry-credentials

--- a/charts/plane-ce/templates/traefik-middleware.yaml
+++ b/charts/plane-ce/templates/traefik-middleware.yaml
@@ -4,10 +4,15 @@ kind: Middleware
 metadata:
   name: {{ .Release.Name }}-body-limit
   labels:
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   buffering:
-    maxRequestBodyBytes: {{ .Values.ingress.traefik.maxRequestBodyBytes | default 5242880 }}
+    {{- /* int64 keeps Helm's float64 YAML numbers from rendering as scientific notation (e.g. 2.097152e+07), which the Traefik CRD's integer field can reject */}}
+    maxRequestBodyBytes: {{ .Values.ingress.traefik.maxRequestBodyBytes | default 5242880 | int64 }}
 
 {{- end }}

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-admin
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.admin.assign_cluster_ip }}
   clusterIP: None
@@ -37,9 +41,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-admin
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.admin) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.admin)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-admin

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-api
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.api.assign_cluster_ip }}
   clusterIP: None
@@ -37,9 +41,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.api) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.api)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -14,9 +14,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-beat-worker
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.beatworker) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.beatworker)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-beat-worker

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-live
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.live.assign_cluster_ip }}
   clusterIP: None
@@ -37,9 +41,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-live
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.live) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.live)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-live

--- a/charts/plane-ce/templates/workloads/migrator.job.yaml
+++ b/charts/plane-ce/templates/workloads/migrator.job.yaml
@@ -4,16 +4,19 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-migrate-{{ .Release.Revision }}
-  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api "job" .Values.api.migrator) }}
 spec:
   backoffLimit: 3
   template:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-api-migrate
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.api "job" .Values.api.migrator) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.api "job" .Values.api.migrator)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-api-migrate

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-minio
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.minio.assign_cluster_ip }}
   clusterIP: None
@@ -40,7 +44,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-minio
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.minio) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.minio)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - image: {{ .Values.minio.image }}
@@ -88,13 +96,19 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-bucket-{{ .Release.Revision }}
-  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.minio) }}
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.minio "job" .Values.minio.bucketJob) }}
 spec:
   backoffLimit: 6
   completionMode: NonIndexed
   template:
     metadata:
       namespace: {{ .Release.Namespace }}
+      labels:
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.minio "job" .Values.minio.bucketJob) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.minio "job" .Values.minio.bucketJob)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: OnFailure
       initContainers:

--- a/charts/plane-ce/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/postgres.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-pgdb
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.postgres.assign_cluster_ip }}
   clusterIP: None
@@ -36,7 +40,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-pgdb
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.postgres) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.postgres)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - image: {{ .Values.postgres.image }}

--- a/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-rabbitmq
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.rabbitmq.assign_cluster_ip }}
   clusterIP: None
@@ -40,7 +44,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-rabbitmq
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.rabbitmq) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.rabbitmq)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - image: {{ .Values.rabbitmq.image }}

--- a/charts/plane-ce/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/redis.stateful.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-redis
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.redis.assign_cluster_ip }}
   clusterIP: None
@@ -38,7 +42,11 @@ spec:
     metadata:
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-redis
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.redis) | nindent 8 }}
+      {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.redis)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - image: {{ .Values.redis.image }}

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-space
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.space.assign_cluster_ip }}
   clusterIP: None
@@ -37,9 +41,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-space
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.space) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.space)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-space

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ .Release.Name }}-web
   labels:
     app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
-    {{- include "plane.commonLabels" $ | nindent 4 }}
+    {{- include "plane.resourceLabels" $ | nindent 4 }}
+  {{- with (include "plane.resourceAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.web.assign_cluster_ip }}
   clusterIP: None
@@ -37,9 +41,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-web
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.web) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.web)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-web

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -14,9 +14,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       labels:
         app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-worker
-        {{- include "plane.commonLabels" $ | nindent 8 }}
+        {{- include "plane.podLabels" (dict "context" $ "values" .Values.worker) | nindent 8 }}
       annotations:
         timestamp: {{ now | quote }}
+        {{- with (include "plane.podAnnotations" (dict "context" $ "values" .Values.worker)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-worker

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -1,5 +1,17 @@
 planeVersion: v1.2.0
 
+# Chart-wide labels/annotations added to the metadata of EVERY resource the chart
+# creates (Deployments, StatefulSets, Jobs, Services, ConfigMaps, Secrets, certs,
+# Ingress/IngressRoute, ServiceAccount, Middleware, ...) AND to every pod template.
+# Useful for cost-allocation, ownership, NetworkPolicy/service-mesh targeting,
+# Prometheus scrape hints, external-dns, etc. These are additive and never injected
+# into a selector/matchLabels. For a narrower scope, use:
+#   - <component>.labels / annotations       -> that workload's OBJECT only
+#   - <component>.podLabels / podAnnotations -> that workload's PODS only
+# Per-component maps win over these chart-wide values on key conflicts.
+commonLabels: {}
+commonAnnotations: {}
+
 dockerRegistry:
   enabled: false
   host: "index.docker.io/v1/"
@@ -41,6 +53,8 @@ redis:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -55,6 +69,8 @@ postgres:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -73,6 +89,8 @@ rabbitmq:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -89,6 +107,15 @@ minio:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
+  # Extra metadata for the one-shot bucket-setup Job ONLY (inherits minio's maps
+  # above; keys here win on conflict). See api.migrator for typical uses.
+  bucketJob:
+    labels: {}
+    annotations: {}
+    podLabels: {}
+    podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -106,6 +133,8 @@ web:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -121,6 +150,8 @@ space:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -136,6 +167,8 @@ admin:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -151,6 +184,8 @@ live:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -166,6 +201,18 @@ api:
   assign_cluster_ip: false
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
+  # Extra metadata for the one-shot db-migration Job ONLY. The Job inherits all of
+  # api's labels/annotations/podLabels/podAnnotations above; keys set here WIN over
+  # the inherited ones on conflict. Typical uses: turn OFF service-mesh sidecar
+  # injection so the Job can complete (sidecar.istio.io/inject: "false"), Vault
+  # agent-pre-populate-only, or GitOps hook annotations (argocd.argoproj.io/hook).
+  migrator:
+    labels: {}
+    annotations: {}
+    podLabels: {}
+    podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -180,6 +227,8 @@ worker:
   pullPolicy: Always
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -194,6 +243,8 @@ beatworker:
   pullPolicy: Always
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## What

Community-chart counterpart of #262. Makes labels/annotations user-configurable across the entire `plane-ce` chart, layered on top of the standard recommended labels from #257. Adds to `values.yaml` (plane-ce uses flat component keys):

```yaml
commonLabels: {}          # every object + every pod template
commonAnnotations: {}
api:
  labels: {}              # (pre-existing) that workload's object metadata
  annotations: {}
  podLabels: {}           # NEW: that workload's pod template only
  podAnnotations: {}
  migrator:               # NEW: override tier for the one-shot migration Job
    labels: {}
    annotations: {}
    podLabels: {}
    podAnnotations: {}
minio:
  bucketJob: {...}        # same override tier for the bucket-setup Job
```

Precedence on key conflict: **job override > per-component > common > standard labels**. All chart objects (Deployments, StatefulSets, Jobs, Services, ConfigMaps, Secrets, certs, Ingress/IngressRoute, ServiceAccount, Middleware) and all 12 pod templates are wired through shared helpers in `templates/_helpers.tpl`, for all 11 components.

## Why

- **Pod-level metadata is what runtime tooling matches on**: NetworkPolicy/Cilium `podSelector`, service-mesh injection, Prometheus scrape annotations, Vault agent injection. The chart previously exposed only object-level `<component>.labels`, so none of these integrations could target Plane pods.
- **Chart-wide `commonLabels`/`commonAnnotations`** (Grafana/GitLab convention) enable cost-allocation, ownership, and GitOps grouping without repeating maps per component.
- **The job override tier** solves the meshed-cluster failure: `sidecar.istio.io/inject: "true"` on api pods would be inherited by the migration Job, whose sidecar never exits, so the Job never completes. Jobs inherit the parent component's maps and selectively override (`inject: "false"`), and can take Job-only object annotations like `argocd.argoproj.io/hook: PreSync`.

## Scope / behavior

- **Default behavior unchanged**: all new values default to `{}`; with defaults the rendered output is identical to master except the two bug-fixes below.
- **`helm upgrade` safe**: nothing is ever injected into `spec.selector`/`matchLabels` — selectors stay on the immutable `app.name` label. Verified all 20 selectors byte-identical between unlabeled and fully-labeled renders.
- The nginx `Ingress` merges `commonAnnotations` with the existing `ingress.ingress_annotations` (ingress-specific wins). Traefik `IngressRoute`s/`Middleware` get the common maps too.
- Helper rename (internal only): `plane.commonLabels` (#257) → `plane.standardLabels`, freeing the "common" name for the user-facing values key; new `plane.resourceLabels`/`plane.resourceAnnotations`/`plane.podLabels`/`plane.podAnnotations` compose the tiers.

### Bug fixes (found while testing)
1. **MinIO bucket Job pod template had no labels at all** (missed in #257 as well) — now carries standard + configured labels like every other pod.
2. **Traefik `Middleware` rendered `maxRequestBodyBytes: 2.097152e+07`** (Helm float64 scientific notation), which the CRD's integer field can reject — now `| int64`, renders `20971520`.

## Testing

- `helm lint` clean; chart version bumped 1.6.0 → 1.7.0.
- 5-scenario render-assertion suite (~1,500 programmatic assertions via `helm template` + YAML parsing): defaults (standard labels everywhere, zero leak), full combo (common + per-component + precedence conflicts: `postgres.podLabels.team` beats `commonLabels.team`; migrator overrides istio inject while inheriting prometheus annotations; ArgoCD hook on Job object only; bucket Job pod labels), nginx ingress annotation merge conflict, standard-label override escape hatch, special-character values (JSON/unicode/URLs/numeric strings stay strings).
- Selector-immutability check: 20 shared selectors identical across unlabeled vs fully-labeled renders.

## Upgrade notes

None required. Existing releases upgrade in place; new labels/annotations only appear if the operator sets the new values.

## Related

- Community counterpart of #262 (plane-enterprise, INFRA-437).
- Builds on #257 (standard recommended labels, INFRA-423).
- Work item: [INFRA-438]

🤖 Generated with [Claude Code](https://claude.com/claude-code)