### PR TITLE
release: Plane-EE:v2.6.4

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -6,7 +6,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 type: application
 
 version: 2.8.1
-appVersion: "2.6.3"
+appVersion: "2.6.4"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -99,7 +99,7 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
    Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
    ```bash
-   PLANE_VERSION=v2.6.3 # or the last released version
+   PLANE_VERSION=v2.6.4 # or the last released version
    DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
    ```
 
@@ -155,7 +155,7 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
 
      Make sure you set the minimum required values as below.
 
-     - `planeVersion: v2.6.3 <or the last released version>`
+     - `planeVersion: v2.6.4 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
      - `ingress.ingressClass: <traefik or any other ingress class configured in your cluster>`
@@ -181,7 +181,7 @@ The default value is `"traefik"`. If you are switching to a standard ingress con
 
 | Setting               |      Default      | Required | Description                                                                                                                                                                          |
 | --------------------- | :---------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| planeVersion          |      v2.6.3       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
+| planeVersion          |      v2.6.4       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
 | license.licenseDomain | plane.example.com |   Yes    | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Air-gapped Settings

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -27,7 +27,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v2.6.3
+  default: v2.6.4
   required: true
   group: "Docker Registry"
   subquestions:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v2.6.3
+planeVersion: v2.6.4
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Plane Enterprise deployment version from **v2.6.3** to **v2.6.4**.
  * Updated the default installation settings and documented version references to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->