### PR TITLE
[INFRA-465] chore: add IS_SELF_MANAGED and AI usage env vars to plane-enterprise

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 3.0.0
+version: 3.0.1
 appVersion: "3.0.0"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -970,6 +970,14 @@ questions:
     label: "CORS Allowed Origins"
     type: string
     default: ""
+  - variable: env.pi_envs.ai_usage_agent_max_tokens_budget
+    label: "AI Usage Agent Max Tokens Budget"
+    type: string
+    default: ""
+  - variable: env.pi_envs.ai_usage_enforcement_enabled
+    label: "AI Usage Enforcement Enabled"
+    type: boolean
+    default: true
   - variable: env.pi_envs.celery.vector_sync_enabled
     label: "Vector Sync Enabled"
     type: boolean

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -111,5 +111,4 @@ data:
 
   WEBHOOK_ALLOWED_IPS: {{ .Values.env.webhook_allowed_ips | default "" | quote }}
   WEBHOOK_ALLOWED_HOSTS: {{ .Values.env.webhook_allowed_hosts | default "" | quote }}
-  IS_SELF_MANAGED: "0"
   AI_USAGE_AGENT_MAX_TOKENS_BUDGET: {{ .Values.env.pi_envs.ai_usage_agent_max_tokens_budget | default "" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -111,3 +111,5 @@ data:
 
   WEBHOOK_ALLOWED_IPS: {{ .Values.env.webhook_allowed_ips | default "" | quote }}
   WEBHOOK_ALLOWED_HOSTS: {{ .Values.env.webhook_allowed_hosts | default "" | quote }}
+  IS_SELF_MANAGED: "0"
+  AI_USAGE_AGENT_MAX_TOKENS_BUDGET: {{ .Values.env.pi_envs.ai_usage_agent_max_tokens_budget | default "" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
@@ -157,6 +157,10 @@ data:
   BR_AWS_REGION: {{ .Values.services.pi.ai_providers.embedding_model.aws_region | default "us-east-1" | quote }}
   {{- end }}
 
+  IS_SELF_MANAGED: "0"
+  AI_USAGE_AGENT_MAX_TOKENS_BUDGET: {{ .Values.env.pi_envs.ai_usage_agent_max_tokens_budget | default "" | quote }}
+  AI_USAGE_ENFORCEMENT_ENABLED: {{ .Values.env.pi_envs.ai_usage_enforcement_enabled | default true | ternary "1" "0" | quote }}
+
   CELERY_VECTOR_SYNC_ENABLED: {{ .Values.env.pi_envs.celery.vector_sync_enabled | ternary "1" "0" | quote }}
   CELERY_VECTOR_SYNC_INTERVAL: {{ .Values.env.pi_envs.celery.vector_sync_interval | default 3 | quote }}
   CELERY_WORKSPACE_PLAN_SYNC_ENABLED: {{ .Values.env.pi_envs.celery.workspace_plan_sync_enabled | ternary "1" "0" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
@@ -159,7 +159,7 @@ data:
 
   IS_SELF_MANAGED: "0"
   AI_USAGE_AGENT_MAX_TOKENS_BUDGET: {{ .Values.env.pi_envs.ai_usage_agent_max_tokens_budget | default "" | quote }}
-  AI_USAGE_ENFORCEMENT_ENABLED: {{ .Values.env.pi_envs.ai_usage_enforcement_enabled | default true | ternary "1" "0" | quote }}
+  AI_USAGE_ENFORCEMENT_ENABLED: {{ .Values.env.pi_envs.ai_usage_enforcement_enabled | ternary "1" "0" | quote }}
 
   CELERY_VECTOR_SYNC_ENABLED: {{ .Values.env.pi_envs.celery.vector_sync_enabled | ternary "1" "0" | quote }}
   CELERY_VECTOR_SYNC_INTERVAL: {{ .Values.env.pi_envs.celery.vector_sync_interval | default 3 | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/pi-api-env.yaml
@@ -157,7 +157,6 @@ data:
   BR_AWS_REGION: {{ .Values.services.pi.ai_providers.embedding_model.aws_region | default "us-east-1" | quote }}
   {{- end }}
 
-  IS_SELF_MANAGED: "0"
   AI_USAGE_AGENT_MAX_TOKENS_BUDGET: {{ .Values.env.pi_envs.ai_usage_agent_max_tokens_budget | default "" | quote }}
   AI_USAGE_ENFORCEMENT_ENABLED: {{ .Values.env.pi_envs.ai_usage_enforcement_enabled | ternary "1" "0" | quote }}
 

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -677,6 +677,9 @@ env:
     internal_secret: 'tyfvfqvBJAgpm9bzvf3r4urJer0Ehfdubk'
     log_level: 'DEBUG'
 
+    ai_usage_agent_max_tokens_budget: ''
+    ai_usage_enforcement_enabled: true
+
     celery:
       vector_sync_enabled: false
       vector_sync_interval: 3


### PR DESCRIPTION
### Description

Add new environment variables to the `plane-enterprise` Helm chart to align with the commercial deployment configs:

- **`IS_SELF_MANAGED`** — hardcoded to `"0"` in both `app-vars` (api) and `pi-api-vars` (pi-*) ConfigMaps. Cloud deployment is always `0`; no `values.yaml` or `questions.yml` entry needed.
- **`AI_USAGE_AGENT_MAX_TOKENS_BUDGET`** — added to `app-vars` (api) and `pi-api-vars` (pi-*); configurable via `env.pi_envs.ai_usage_agent_max_tokens_budget`, default: empty.
- **`AI_USAGE_ENFORCEMENT_ENABLED`** — added to `pi-api-vars` (pi-* only); configurable via `env.pi_envs.ai_usage_enforcement_enabled`, default: `true` (renders as `"1"`).
- Bump chart version `3.0.0` → `3.0.1`.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios
- Deploy chart and verify `IS_SELF_MANAGED=0` is present in the `api` pod environment (`kubectl exec <api-pod> -- env | grep IS_SELF_MANAGED`)
- Verify `AI_USAGE_AGENT_MAX_TOKENS_BUDGET` is present in both `api` and `pi-api` pod environments
- Verify `AI_USAGE_ENFORCEMENT_ENABLED=1` is present in `pi-api` pod but **not** in `api` pod
- Set `env.pi_envs.ai_usage_enforcement_enabled: false` in values and confirm the env renders as `"0"`
- Run `helm lint` — should pass with 0 failures

### References
- INFRA-465
- Related: INFRA-464 (same vars added to Docker/AIO/Portainer/Coolify deployment configs)

---
_Generated with [Claude Code](https://claude.ai/claude-code)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration options for AI usage enforcement and maximum agent token budgets.
  - AI usage enforcement is enabled by default and can be adjusted during deployment.
  - Added support for applying these settings across application and AI services.
  - Added self-managed deployment identification to service configuration.

- **Chores**
  - Updated the enterprise Helm chart release version to 3.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->