### PR TITLE
[INFRA-471] - release: Plane-CE v1.4.0

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.6.0
-appVersion: "1.3.1"
+version: 1.6.1
+appVersion: "1.4.0"
 
 home: https://plane.so
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -44,7 +44,7 @@
        helm upgrade --install plane-app makeplane/plane-ce \
            --create-namespace \
            --namespace plane-ce \
-           --set planeVersion=v1.3.1 \
+           --set planeVersion=v1.4.0 \
            --set ingress.appHost="plane.example.com" \
            --set ingress.minioHost="plane-minio.example.com" \
            --set ingress.rabbitmqHost="plane-mq.example.com" \
@@ -163,7 +163,7 @@ The default value is `"traefik"`. If you previously relied on the implicit defau
 
 | Setting      | Default | Required | Description |
 | ------------ | :-----: | :------: | ----------- |
-| planeVersion | v1.3.1  |   Yes    |             |
+| planeVersion | v1.4.0  |   Yes    |             |
 
 ### Postgress DB Setup
 

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -20,7 +20,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v1.2.0
+  default: v1.4.0
   required: true
   group: "Docker Registry"
 

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v1.2.0
+planeVersion: v1.4.0
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION
## What

Bumps the Plane CE Helm chart to track the `v1.4.0` app release:

- `Chart.yaml`: `version` 1.6.0 → 1.6.1, `appVersion` 1.3.1 → 1.4.0
- `values.yaml` + `questions.yml`: `planeVersion` default v1.2.0 → v1.4.0
- `README.md`: install snippet updated to reference `v1.4.0`

```yaml
# Chart.yaml
version: 1.6.1
appVersion: "1.4.0"

# values.yaml / questions.yml
planeVersion: v1.4.0
```

## Why

Tracks the Plane CE application release `v1.4.0`. Keeping `planeVersion` in sync ensures the Rancher catalog form and default `helm install` commands pull the correct image tag out of the box.

## Scope / behavior

- **No template changes** — only version string defaults are updated.
- Users with a pinned `planeVersion` in their `values.yaml` are **unaffected**; this only changes the default for fresh installs or upgrades that omit the flag.
- No changes to `plane-enterprise` or any other chart.

## Testing

No `helm template` run was needed — the change is purely a string default. `helm lint` passes cleanly on the chart.

## Related

Plane work item: INFRA-471

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Plane Community Edition Helm chart to version 1.4.0.
  * Installation examples and default configuration now use the Plane 1.4.0 image and version.
  * Updated the Helm chart release version to 1.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->