### PR TITLE
[INFRA-481] - feat(plane-enterprise): add Microsoft Teams integration secrets to silo

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 3.1.0
+version: 3.1.1
 appVersion: "3.0.1"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -440,6 +440,34 @@ questions:
     type: string
     default: ""
 
+- variable: services.silo.connectors.microsoft_teams.enabled
+  label: "Microsoft Teams Integration"
+  type: boolean
+  default: false
+  group: "Silo Connectors"
+  show_subquestion_if: true
+  subquestions:
+  - variable: services.silo.connectors.microsoft_teams.client_id
+    label: "MS Teams Client ID"
+    type: string
+    default: ""
+  - variable: services.silo.connectors.microsoft_teams.client_secret
+    label: "MS Teams Client Secret"
+    type: password
+    default: ""
+  - variable: services.silo.connectors.microsoft_teams.tenant_id
+    label: "MS Teams Tenant ID"
+    type: string
+    default: ""
+  - variable: services.silo.connectors.microsoft_teams.app_id
+    label: "MS Teams App ID"
+    type: string
+    default: ""
+  - variable: services.silo.connectors.microsoft_teams.app_type
+    label: "MS Teams App Type"
+    type: string
+    default: "MultiTenant"
+
 - variable: services.monitor.pullPolicy
   label: "Monitor Pull Policy"
   type: enum

--- a/charts/plane-enterprise/templates/config-secrets/silo.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/silo.yaml
@@ -57,6 +57,13 @@ stringData:
   SENTRY_CLIENT_SECRET: {{ .Values.services.silo.connectors.sentry.client_secret | default "" | quote }}
   SENTRY_INTEGRATION_SLUG: {{ .Values.services.silo.connectors.sentry.integration_slug | default "" | quote }}
   {{- end }}
+  {{- if .Values.services.silo.connectors.microsoft_teams.enabled }}
+  MS_TEAMS_CLIENT_ID: {{ .Values.services.silo.connectors.microsoft_teams.client_id | default "" | quote }}
+  MS_TEAMS_CLIENT_SECRET: {{ .Values.services.silo.connectors.microsoft_teams.client_secret | default "" | quote }}
+  MS_TEAMS_TENANT_ID: {{ .Values.services.silo.connectors.microsoft_teams.tenant_id | default "" | quote }}
+  MS_TEAMS_APP_ID: {{ .Values.services.silo.connectors.microsoft_teams.app_id | default "" | quote }}
+  MS_TEAMS_APP_TYPE: {{ .Values.services.silo.connectors.microsoft_teams.app_type | default "MultiTenant" | quote }}
+  {{- end }}
 {{- end }}
 ---
 {{- if .Values.services.silo.enabled }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -377,6 +377,13 @@ services:
         client_id: ''
         client_secret: ''
         integration_slug: ''
+      microsoft_teams:
+        enabled: false
+        client_id: ''
+        client_secret: ''
+        tenant_id: ''
+        app_id: ''
+        app_type: 'MultiTenant'
 
   email_service:
     enabled: false


### PR DESCRIPTION
## Summary
- Add `MS_TEAMS_CLIENT_ID`, `MS_TEAMS_CLIENT_SECRET`, `MS_TEAMS_TENANT_ID`, `MS_TEAMS_APP_ID` (default empty) and `MS_TEAMS_APP_TYPE` (default `MultiTenant`) under `services.silo.connectors.microsoft_teams` in `values.yaml`
- Render secrets into `templates/config-secrets/silo.yaml` when the connector is enabled
- Mirror all fields in `questions.yml` for Rancher catalog form
- Bump chart version `3.1.0 → 3.1.1`

## Test plan
- [ ] `helm lint charts/plane-enterprise` passes
- [ ] `helm template` renders MS Teams secrets when `microsoft_teams.enabled=true`
- [ ] Secrets absent from rendered output when `microsoft_teams.enabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft Teams connector configuration for enterprise deployments.
  * Supports enabling the connector and configuring client credentials, tenant ID, application ID, and application type.
  * Securely manages connector credentials during deployment.

* **Chores**
  * Updated the enterprise Helm chart version to 3.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->