### PR TITLE
[INFRA-482] - release: Plane-CE v1.4.1

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.6.1
-appVersion: "1.4.0"
+version: 1.6.2
+appVersion: "1.4.1"
 
 home: https://plane.so
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -44,7 +44,7 @@
        helm upgrade --install plane-app makeplane/plane-ce \
            --create-namespace \
            --namespace plane-ce \
-           --set planeVersion=v1.4.0 \
+           --set planeVersion=v1.4.1 \
            --set ingress.appHost="plane.example.com" \
            --set ingress.minioHost="plane-minio.example.com" \
            --set ingress.rabbitmqHost="plane-mq.example.com" \
@@ -163,7 +163,7 @@ The default value is `"traefik"`. If you previously relied on the implicit defau
 
 | Setting      | Default | Required | Description |
 | ------------ | :-----: | :------: | ----------- |
-| planeVersion | v1.4.0  |   Yes    |             |
+| planeVersion | v1.4.1  |   Yes    |             |
 
 ### Postgress DB Setup
 

--- a/charts/plane-ce/questions.yml
+++ b/charts/plane-ce/questions.yml
@@ -20,7 +20,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v1.4.0
+  default: v1.4.1
   required: true
   group: "Docker Registry"
 

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v1.4.0
+planeVersion: v1.4.1
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION
## What
Bumps the `plane-ce` chart to release Plane-CE v1.4.1:

- `Chart.yaml`: `version: 1.6.1 → 1.6.2`, `appVersion: 1.4.0 → 1.4.1`
- `values.yaml`: `planeVersion: v1.4.0 → v1.4.1`
- `questions.yml`: default version `v1.4.0 → v1.4.1`
- `README.md`: version references updated to `v1.4.1`

## Scope / behavior
Default behavior change — users installing/upgrading without pinning `planeVersion` will get `v1.4.1` images.

## Testing
`helm lint` passed. No template logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Plane CE deployment to version 1.4.1.
  * Updated the Helm chart version to 1.6.2.
  * Updated installation documentation and default configuration values to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->