### PR TITLE
fix: replace deprecated `mc config host add` with `mc alias set`

### DIFF
--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -107,7 +107,7 @@ spec:
           args:
             - '-c'
             - >-
-              /usr/bin/mc config host add plane-app-minio
+              /usr/bin/mc alias set plane-app-minio
               http://{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"; 
               /usr/bin/mc mb plane-app-minio/$AWS_S3_BUCKET_NAME; 
               /usr/bin/mc anonymous set download plane-app-minio/$AWS_S3_BUCKET_NAME; exit 0;

--- a/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-enterprise/templates/workloads/minio.stateful.yaml
@@ -111,7 +111,7 @@ spec:
           args:
             - '-c'
             - >-
-              /usr/bin/mc config host add plane-app-minio
+              /usr/bin/mc alias set plane-app-minio
               http://{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.{{ .Values.env.default_cluster_domain | default "cluster.local" }}:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"; 
               /usr/bin/mc mb plane-app-minio/$AWS_S3_BUCKET_NAME; 
               /usr/bin/mc anonymous set download plane-app-minio/$AWS_S3_BUCKET_NAME; exit 0;


### PR DESCRIPTION
## What

The MinIO bucket-provisioning job uses `mc config host add`, which current `minio/mc` images no longer recognize. Replaced with `mc alias set` in both `plane-ce` and `plane-enterprise`.

```diff
# charts/{plane-ce,plane-enterprise}/templates/workloads/minio.stateful.yaml
-              /usr/bin/mc config host add plane-app-minio
+              /usr/bin/mc alias set plane-app-minio
               http://{{ .Release.Name }}-minio...:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY";
```

`mc alias set` takes the same `ALIAS URL ACCESSKEY SECRETKEY` argument order, so only the subcommand changes. The following `mc mb` and `mc anonymous set` calls are still current and are untouched.

## Why

The job fails with:

```
mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.
```

**This fails silently, which is the important part.** The command chain ends in `exit 0`, so:

1. `mc config host add` errors — the `plane-app-minio` alias is never registered.
2. `mc mb plane-app-minio/uploads` then treats `plane-app-minio/uploads` as a **local filesystem path** and creates a directory inside the container. It prints `Bucket created successfully` — indistinguishable from real success.
3. `mc anonymous set download` likewise reports success against that local path.
4. `exit 0` → Kubernetes marks the Job **Complete**.

So the install looks healthy while the `uploads` bucket **does not exist on MinIO**. The failure only surfaces later as broken file uploads/attachments. Verified on a clean MinIO server: after the old command, `mc ls` returns an empty bucket list.

## Scope / behavior

- **Both charts affected.** `plane-ce` and `plane-enterprise` carry identical command blocks; both are fixed here.
- Only renders when MinIO is chart-managed — the template is wrapped in `{{- if .Values.minio.local_setup }}` (CE) / `{{- if .Values.services.minio.local_setup }}` (EE). Installs using external S3 are unaffected.
- **One-line subcommand swap per chart.** No values, no defaults, no other templates, no chart versions changed.
- Existing installs whose bucket was created manually (or before `mc` dropped `config`) are unaffected — `mc mb` on an existing bucket is a no-op the job already tolerates.

## Testing

Verified against `minio/mc:latest` and a live `minio/minio:latest` server in Docker.

**1. Confirmed the deprecation is real:**
```
$ mc config host add ...
mc: <ERROR> `config` is not a recognized command.
$ mc alias set --help
USAGE: mc alias set ALIAS URL ACCESSKEY SECRETKEY
```

**2. Confirmed the silent-failure impact** — ran the *old* command against a clean server, then listed buckets:
```
Bucket created successfully `plane-app-minio/oldbucket`.   <- misleading
Access permission ... is set to `download`                 <- misleading
$ mc ls <server>
(empty — no bucket was created)
```

**3. Ran the exact rendered command from `helm template`** (host swapped for the test container) against a live server:
```
Added `plane-app-minio` successfully.
Bucket created successfully `plane-app-minio/uploads`.
Access permission for `plane-app-minio/uploads` is set to `download`

$ mc ls <server>
[2026-08-14 11:04:03 UTC]     0B uploads/
$ mc anonymous get <server>/uploads
Access permission for `<server>/uploads` is `download`
```
The bucket and its anonymous policy now exist on the server.

**4.** `helm lint charts/plane-ce charts/plane-enterprise` → 2 linted, 0 failed. `grep -rn "mc config" charts/` → no matches remaining.

Not deployed to a live Kubernetes cluster; the container-level test above exercises the exact rendered command the Job runs.

## Related

- #286 — makes the busybox image configurable in `plane-ce` (touches the same template; independent branch, no conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MinIO setup during deployment to use the current alias configuration command.
  * Improved compatibility with newer MinIO client versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->