### PR TITLE
[INFRA-488] - Fix chart-releaser: add helm repo before dependency update

### DIFF
--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -110,6 +110,11 @@ jobs:
           echo "MARK_AS_PRERELASE=true" >> $GITHUB_ENV
           echo "PAGES_INDEX_PATH=${flatBranchName}" >> $GITHUB_ENV
 
+      - name: Add Helm repos
+        run: |
+          helm repo add valkey https://valkey.io/valkey-helm/
+          helm repo update
+
       - name: Update chart dependencies
         run: |
           for chart in charts/*/; do


### PR DESCRIPTION
## Summary

- Add explicit `helm repo add valkey` step before `helm dependency update` so the repo is registered on fresh CI runners
- Without this, `cr package` fails with `no repository definition for https://valkey.io/valkey-helm/`

## Test plan

- [ ] Trigger chart-releaser workflow for `plane-mcp-server` and verify packaging succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)