### PR TITLE
fix: repin chart releaser to makeplane/chart-releaser-action@v1.7.0-plane.1

### DIFF
--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -124,7 +124,7 @@ jobs:
           done
 
       - name: Release Charts
-        uses: mguptahub/chart-releaser-action@v1.6.2
+        uses: makeplane/chart-releaser-action@v1.7.0-plane.1
         with:
           charts_dir: charts
           config: cr.yaml


### PR DESCRIPTION
## Problem

Chart Release has been failing since **19 Aug**. Every run dies at job setup:

```
##[error]Unable to resolve action mguptahub/chart-releaser-action, repository not found
```

The workflow referenced `mguptahub/chart-releaser-action@v1.6.2` — a personal fork that has since been deleted. The last successful release was **18 Aug 13:27**, so no chart has shipped since.

## Why upstream can't just be swapped in

This workflow passes two inputs that upstream `helm/chart-releaser-action` does not have:

| Input | Used for |
| :--- | :--- |
| `prerelease` | Marks branch releases as *Pre-release* |
| `pages_index_path` | Publishes a branch-scoped index under `gh-pages/<branch>/`, which is what `develop/`, `airgapped-rc1/`, `airgapped-rc2/` and `add-minio-envs/` on `gh-pages` are |

Pointing at upstream fails on unknown-input. The deleted fork also pulled the `chart-releaser` **binary** from a second personal fork, `mguptahub/chart-releaser`, which is likewise gone.

## Fix

Both inputs have been ported onto the org fork and released as `makeplane/chart-releaser-action@v1.7.0-plane.1`. This PR is the one-line repin.

Notes on that fork, for context:

- `pages_index_path` maps directly onto `cr`'s own `--pages-index-path`, which upstream gained in **v1.7.0**. Backporting that flag was the main reason the old fork needed a patched `cr` binary — on v1.7.0 **no patched binary is required**, so the deleted binary fork does not need recreating.
- `prerelease` has no upstream equivalent in any `cr` version: `cr` never sets the `prerelease` field on the GitHub API payload, and every proposal to add the flag has been closed unmerged. It is applied by patching the releases with the GitHub CLI after upload, ordered to run *after* the index is published so a failure to apply cosmetic release metadata cannot leave charts released but unindexed.
- Pinned to the **tag**, not `main`, so a later change to the fork cannot silently alter chart releases.

## Risk

Low for `master`. On `master`, `MARK_AS_PRERELASE` is `false` and `PAGES_INDEX_PATH` is `""`, so both new inputs are inert and the action behaves identically to upstream v1.7.0. The custom paths only engage on a non-`master` ref.

## Verification

The fork's `cr.sh` was exercised with stubbed `cr` and `gh` binaries across four cases — master-like, branch-like, `--skip-packaging`, `--skip-upload` — asserting the exact arguments produced. Confirmed: `--prerelease` is never passed to the `cr` binary (which would reject it), an empty `pages_index_path` omits the flag entirely, and the no-packages path does not trip `nounset`. `shellcheck` is clean and all 7 inputs this workflow passes resolve against the tag.

A dispatch run has **not** been triggered yet.

## Follow-ups (not in this PR)

- A bare `pages_index_path` requires that directory to already exist on `gh-pages`; `cr` writes the index without creating intermediate directories, so a brand-new branch name will fail until the directory is pre-created.
- Upstream interpolates `${{ inputs.* }}` straight into the composite action's `run:` block for every input — a script-injection pattern worth hardening in the fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the chart release process to use the latest release tooling, improving reliability for published chart updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->