### PR TITLE
[INFRA-500] - release: Update Plane-EE to version v3.1.2

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 3.5.0
-appVersion: "3.1.1"
+version: 3.5.1
+appVersion: "3.1.2"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -301,7 +301,7 @@ ingress:
    Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
    ```bash
-   PLANE_VERSION=v3.1.1 # or the last released version
+   PLANE_VERSION=v3.1.2 # or the last released version
    DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
    ```
 
@@ -357,7 +357,7 @@ ingress:
 
      Make sure you set the minimum required values as below.
 
-     - `planeVersion: v3.1.1 <or the last released version>`
+     - `planeVersion: v3.1.2 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
      - `ingress.ingressClass: <traefik or any other ingress class configured in your cluster>`
@@ -383,7 +383,7 @@ ingress:
 
 | Setting               |      Default      | Required | Description                                                                                                                                                                          |
 | --------------------- | :---------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| planeVersion          |      v3.1.1       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
+| planeVersion          |      v3.1.2       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
 | license.licenseDomain | plane.example.com |   Yes    | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Air-gapped Settings
@@ -787,7 +787,6 @@ securityContext:
 | services.silo.connectors.bitbucket.client_id  |                      ""                      | required if `services.silo.connectors.bitbucket.enabled` is `true` | Bitbucket OAuth Client ID                                                                                                                                                                                    |
 | services.silo.connectors.bitbucket.client_secret |                    ""                      | required if `services.silo.connectors.bitbucket.enabled` is `true` | Bitbucket OAuth Client Secret                                                                                                                                                                                |
 | services.silo.connectors.bitbucket.webhook_secret |                   ""                      |                                                                 | Bitbucket Webhook Secret (`BITBUCKET_WEBHOOK_SECRET`) for verifying incoming webhook payloads                                                                                                                   |
-
 | services.silo.connectors.hubspot.enabled      |                    false                     |                                                                 | HubSpot Integration                                                                                                                                                                                             |
 | services.silo.connectors.hubspot.client_id    |                      ""                      | required if `services.silo.connectors.hubspot.enabled` is `true` | HubSpot OAuth Client ID                                                                                                                                                                                       |
 | services.silo.connectors.hubspot.client_secret |                     ""                      | required if `services.silo.connectors.hubspot.enabled` is `true` | HubSpot OAuth Client Secret                                                                                                                                                                                   |

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -27,7 +27,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v3.1.1
+  default: v3.1.2
   required: true
   group: "Docker Registry"
   subquestions:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v3.1.1
+planeVersion: v3.1.2
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION
## What

Bumps the `plane-enterprise` chart to release Plane **v3.1.2**:

- `Chart.yaml`: `version` 3.5.0 → 3.5.1, `appVersion` 3.1.1 → 3.1.2
- `values.yaml` / `questions.yml`: `planeVersion` default v3.1.1 → v3.1.2
- `README.md`: three version reference updates + one table fix (see below)

## Why

Routine patch release to ship Plane v3.1.2 to enterprise chart users.

## Scope / behavior

- **`planeVersion` default change** — operators who leave the value unset will pull `v3.1.2` images instead of `v3.1.1` after upgrade. Operators pinning their own version are unaffected.
- **No template changes** — only metadata, defaults, and docs are touched; no rendered Kubernetes objects change.
- **README table fix** — a stray blank line after the `services.silo.connectors.bitbucket.webhook_secret` row was splitting the Silo connector table into two at render time; removed.

Key diff:
```yaml
# Chart.yaml
-version: 3.5.0
-appVersion: "3.1.1"
+version: 3.5.1
+appVersion: "3.1.2"

# values.yaml
-planeVersion: v3.1.1
+planeVersion: v3.1.2
```

## Testing

`helm lint` and `helm template` were not run for this change as it is metadata/docs-only with no template modifications.

## Related

Plane work item: [INFRA-500]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated the Plane Enterprise release to version **v3.1.2**.
  * Updated the Helm chart version to **3.5.1**.
  * Updated installation defaults and documentation to reference the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->