### PR TITLE
[SILO-1523] feat(plane-enterprise): add integration event stream env vars + integration-event-consumer deployment

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 3.5.1
+version: 3.6.0
 appVersion: "3.1.2"
 
 home: https://plane.so/

--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -6,7 +6,7 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 type: application
 
 version: 3.6.0
-appVersion: "3.1.2"
+appVersion: "3.1.4"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -1037,6 +1037,46 @@ questions:
     type: int
     default: 10
 
+- variable: services.integration_event_consumer.enabled
+  label: "Enable Integration Event Consumer"
+  type: boolean
+  default: false
+  group: "Integration Event Consumer Setup"
+  show_subquestion_if: true
+  subquestions:
+  - variable: services.integration_event_consumer.replicas
+    label: "Default Replica Count"
+    type: int
+    default: 1
+  - variable: services.integration_event_consumer.memoryLimit
+    label: "Memory Limit"
+    type: string
+    default: 1000Mi
+  - variable: services.integration_event_consumer.cpuLimit
+    label: "CPU Limit"
+    type: string
+    default: 500m
+  - variable: services.integration_event_consumer.memoryRequest
+    label: "Memory Request"
+    type: string
+    default: 256Mi
+  - variable: services.integration_event_consumer.cpuRequest
+    label: "CPU Request"
+    type: string
+    default: 100m
+  - variable: services.integration_event_consumer.assign_cluster_ip
+    label: "Assign Cluster IP"
+    type: boolean
+    default: false
+  - variable: env.integration_event_consumer_envs.queue_name
+    label: "Integration Event Consumer Queue Name"
+    type: string
+    default: "plane.integration_stream.reference"
+  - variable: env.integration_event_consumer_envs.prefetch_count
+    label: "Integration Event Consumer Prefetch Count"
+    type: int
+    default: 10
+
 - variable: services.iframely.enabled
   label: "Enable Iframely"
   type: boolean

--- a/charts/plane-enterprise/templates/config-secrets/app-env.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/app-env.yaml
@@ -116,3 +116,17 @@ data:
   WEBHOOK_ALLOWED_IPS: {{ .Values.env.webhook_allowed_ips | default "" | quote }}
   WEBHOOK_ALLOWED_HOSTS: {{ .Values.env.webhook_allowed_hosts | default "" | quote }}
   AI_USAGE_AGENT_MAX_TOKENS_BUDGET: {{ .Values.env.pi_envs.ai_usage_agent_max_tokens_budget | default "" | quote }}
+
+  INTEGRATION_EVENT_STREAM_EXCHANGE_NAME: {{ .Values.env.integration_event_envs.stream_exchange_name | default "plane.integration_stream" | quote }}
+  INTEGRATION_EVENT_CONSUMER_QUEUE_NAME: {{ .Values.env.integration_event_consumer_envs.queue_name | default "plane.integration_stream.reference" | quote }}
+  INTEGRATION_EVENT_CONSUMER_PREFETCH: {{ .Values.env.integration_event_consumer_envs.prefetch_count | default 10 | quote }}
+  INTEGRATION_EVENT_MAX_RAW_BYTES: {{ .Values.env.integration_event_envs.max_raw_bytes | default 262144 | quote }}
+  INTEGRATION_EVENT_PUBLISH_TIMEOUT: {{ .Values.env.integration_event_envs.publish_timeout | default 2.0 | quote }}
+  INTEGRATION_EVENT_PUBLISH_MAX_RETRIES: {{ .Values.env.integration_event_envs.publish_max_retries | default 2 | quote }}
+  INTEGRATION_EVENT_PUBLISH_RETRY_DELAY: {{ .Values.env.integration_event_envs.publish_retry_delay | default 0.05 | quote }}
+  INTEGRATION_EVENT_REPUBLISH_BATCH_SIZE: {{ .Values.env.integration_event_envs.republish_batch_size | default 500 | quote }}
+  INTEGRATION_EVENT_REPUBLISH_MAX_ATTEMPTS: {{ .Values.env.integration_event_envs.republish_max_attempts | default 10 | quote }}
+  INTEGRATION_EVENT_REPUBLISH_GRACE_SECONDS: {{ .Values.env.integration_event_envs.republish_grace_seconds | default 60 | quote }}
+  INTEGRATION_EVENT_CLEANER_BATCH_SIZE: {{ .Values.env.integration_event_envs.cleaner_batch_size | default 1000 | quote }}
+  INTEGRATION_EVENT_CLEANER_CUTOFF_DAYS: {{ .Values.env.integration_event_envs.cleaner_cutoff_days | default 7 | quote }}
+  INTEGRATION_EVENT_COLLECTION_NAME: {{ .Values.env.integration_event_envs.collection_name | default "integration_event" | quote }}

--- a/charts/plane-enterprise/templates/config-secrets/integration-event-consumer.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/integration-event-consumer.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.services.integration_event_consumer.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-integration-event-consumer-vars
+  labels:
+    {{- include "plane.commonLabels" $ | nindent 4 }}
+data:
+  INTEGRATION_EVENT_CONSUMER_QUEUE_NAME: {{ .Values.env.integration_event_consumer_envs.queue_name | default "plane.integration_stream.reference" | quote }}
+  INTEGRATION_EVENT_CONSUMER_PREFETCH: {{ .Values.env.integration_event_consumer_envs.prefetch_count | default 10 | quote }}
+---
+{{- end }}

--- a/charts/plane-enterprise/templates/config-secrets/silo.yaml
+++ b/charts/plane-enterprise/templates/config-secrets/silo.yaml
@@ -122,6 +122,10 @@ data:
   SENTRY_ENVIRONMENT: {{ .Values.env.silo_envs.sentry_environment | default "development" | quote }}
   SENTRY_TRACES_SAMPLE_RATE: {{ .Values.env.silo_envs.sentry_traces_sample_rate | default "0.1" | quote }}
 
+  INTEGRATION_EVENT_INGEST_ENABLED: {{ .Values.env.silo_envs.integration_event_ingest_enabled | default false | ternary "1" "0" | quote }}
+  INTEGRATION_EVENT_PROVIDERS: {{ .Values.env.silo_envs.integration_event_providers | default "github,gitlab,slack" | quote }}
+  INTEGRATION_EVENT_INGEST_TIMEOUT_MS: {{ .Values.env.silo_envs.integration_event_ingest_timeout_ms | default 2000 | quote }}
+
 
 {{- end }}
 ---

--- a/charts/plane-enterprise/templates/workloads/integration-event-consumer.deployment.yaml
+++ b/charts/plane-enterprise/templates/workloads/integration-event-consumer.deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.services.integration_event_consumer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-integration-event-consumer-wl
+  {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.services.integration_event_consumer) }}
+spec:
+  replicas: {{ .Values.services.integration_event_consumer.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-integration-event-consumer
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app.name: {{ .Release.Namespace }}-{{ .Release.Name }}-integration-event-consumer
+        {{- include "plane.commonLabels" $ | nindent 8 }}
+      annotations:
+        timestamp: {{ now | quote }}
+    spec:
+      {{- include "plane.podScheduling" .Values.services.integration_event_consumer }}
+      {{- include "plane.podSecurityContext" . }}
+      containers:
+      - name: {{ .Release.Name }}-integration-event-consumer
+        {{- include "plane.containerSecurityContext" . }}
+        imagePullPolicy: {{ .Values.services.api.pullPolicy | default "Always" }}
+        image: {{ .Values.services.api.image | default "makeplane/backend-commercial" }}:{{ .Values.planeVersion }}
+        stdin: true
+        tty: true
+        resources:
+          requests:
+            memory: {{ .Values.services.integration_event_consumer.memoryRequest | default "256Mi" | quote }}
+            cpu: {{ .Values.services.integration_event_consumer.cpuRequest | default "100m" | quote }}
+          limits:
+            memory: {{ .Values.services.integration_event_consumer.memoryLimit  | default "1000Mi" | quote }}
+            cpu: {{ .Values.services.integration_event_consumer.cpuLimit | default "500m" | quote}}
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - pgrep -f "python" > /dev/null
+          initialDelaySeconds: 10
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        command:
+          - ./bin/docker-entrypoint-integration-event-consumer.sh
+        envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}-integration-event-consumer-vars
+              optional: false
+          - configMapRef:
+              name: {{ .Release.Name }}-app-vars
+              optional: false
+          - secretRef:
+              name: {{ if not (empty .Values.external_secrets.app_env_existingSecret) }}{{ .Values.external_secrets.app_env_existingSecret }}{{ else }}{{ .Release.Name }}-app-secrets{{ end }}
+              optional: false
+          - secretRef:
+              name: {{ if not (empty .Values.external_secrets.doc_store_existingSecret) }}{{ .Values.external_secrets.doc_store_existingSecret }}{{ else }}{{ .Release.Name }}-doc-store-secrets{{ end }}
+              optional: false
+          - secretRef:
+              name: {{ if not (empty .Values.external_secrets.opensearch_existingSecret) }}{{ .Values.external_secrets.opensearch_existingSecret }}{{ else }}{{ .Release.Name }}-opensearch-secrets{{ end }}
+              optional: false
+          {{- if .Values.services.silo.enabled }}
+          - secretRef:
+              name: {{ if not (empty .Values.external_secrets.silo_env_existingSecret) }}{{ .Values.external_secrets.silo_env_existingSecret }}{{ else }}{{ .Release.Name }}-silo-secrets{{ end }}
+              optional: false
+          {{- end }}
+          {{- with (include "plane.otel.envFrom" $) }}{{ . | nindent 10 }}{{- end }}
+        {{- if or .Values.extraEnv (eq (include "plane.otel.enabled" .) "true") }}
+        env:
+          {{- with (include "plane.otel.serviceEnv" (dict "ctx" $ "service" "integration-event-consumer")) }}{{ . | nindent 10 }}{{- end }}
+          {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 10 }}
+          {{- end }}
+        {{- end }}
+
+      serviceAccount: {{ .Release.Name }}-srv-account
+      serviceAccountName: {{ .Release.Name }}-srv-account
+---
+{{- end }}

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -508,6 +508,20 @@ services:
     labels: {}
     annotations: {}
 
+  integration_event_consumer:
+    enabled: false
+    replicas: 1
+    memoryLimit: 1000Mi
+    cpuLimit: 500m
+    memoryRequest: 256Mi
+    cpuRequest: 100m
+    assign_cluster_ip: false
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    labels: {}
+    annotations: {}
+
   pi:
     enabled: false
     replicas: 1
@@ -721,10 +735,28 @@ env:
     jira_server_issues_page_size: 50
     jira_server_issues_parallel_pages: 1
     cursor_webhook_secret: 'TTqazTcoBajYKzIAeIKFZeTX9czAoUsG'
+    # Integration event stream: normalized webhook events Silo forwards to Plane.
+    integration_event_ingest_enabled: false
+    integration_event_providers: "github,gitlab,slack"
+    integration_event_ingest_timeout_ms: 2000
 
   email_service_envs:
     smtp_domain: ''
     max_attachment_size: '10485760' # 10MB in bytes
+
+  # Shared across api / worker / beat-worker / integration-event-consumer.
+  integration_event_envs:
+    stream_exchange_name: "plane.integration_stream"
+    max_raw_bytes: 262144
+    publish_timeout: 2.0
+    publish_max_retries: 2
+    publish_retry_delay: 0.05
+    republish_batch_size: 500
+    republish_max_attempts: 10
+    republish_grace_seconds: 60
+    cleaner_batch_size: 1000
+    cleaner_cutoff_days: 7
+    collection_name: "integration_event"
 
   outbox_poller_envs:
     memory_limit_mb: 400
@@ -754,6 +786,10 @@ env:
 
   agent_consumer_envs:
     queue_name: "plane.agent"
+    prefetch_count: 10
+
+  integration_event_consumer_envs:
+    queue_name: "plane.integration_stream.reference"
     prefetch_count: 10
 
   runner_envs:


### PR DESCRIPTION
## What
Adds the `integration-event-stream` feature's env vars to `charts/plane-enterprise`, and a new `integration-event-consumer` Deployment + ConfigMap.

- `values.yaml` / `questions.yml`: new `services.integration_event_consumer` block (enabled/replicas/resources), `env.integration_event_consumer_envs` (queue name + prefetch), `env.integration_event_envs` (exchange name, publish/republish/cleaner tuning), and three new keys on `env.silo_envs` for Silo's ingest side.
- `templates/config-secrets/app-env.yaml`: adds `INTEGRATION_EVENT_STREAM_EXCHANGE_NAME`, `INTEGRATION_EVENT_CONSUMER_QUEUE_NAME`, `INTEGRATION_EVENT_CONSUMER_PREFETCH`, `INTEGRATION_EVENT_MAX_RAW_BYTES`, `INTEGRATION_EVENT_PUBLISH_TIMEOUT`, `INTEGRATION_EVENT_PUBLISH_MAX_RETRIES`, `INTEGRATION_EVENT_PUBLISH_RETRY_DELAY`, `INTEGRATION_EVENT_REPUBLISH_BATCH_SIZE`, `INTEGRATION_EVENT_REPUBLISH_MAX_ATTEMPTS`, `INTEGRATION_EVENT_REPUBLISH_GRACE_SECONDS`, `INTEGRATION_EVENT_CLEANER_BATCH_SIZE`, `INTEGRATION_EVENT_CLEANER_CUTOFF_DAYS`, `INTEGRATION_EVENT_COLLECTION_NAME` to the shared `app-vars` ConfigMap (consumed by api/worker/beat-worker via their existing `envFrom`).
- `templates/config-secrets/silo.yaml`: adds `INTEGRATION_EVENT_INGEST_ENABLED`, `INTEGRATION_EVENT_PROVIDERS`, `INTEGRATION_EVENT_INGEST_TIMEOUT_MS` to `silo-vars`.
- New `templates/config-secrets/integration-event-consumer.yaml` + `templates/workloads/integration-event-consumer.deployment.yaml`: a dedicated Deployment that reuses the backend image and runs `./bin/docker-entrypoint-integration-event-consumer.sh`, mirroring the existing `webhook-consumer`/`agent-consumer` pattern exactly (own ConfigMap first in `envFrom`, then `app-vars`, app/doc-store/opensearch/silo secrets, otel hooks, readinessProbe via `pgrep -f "python"`).
- Bumps `Chart.yaml` version `3.5.1 → 3.6.0`.

## Why
plane-ee's new [Integration Event Stream](https://github.com/makeplane/plane-ee/blob/main/docs/integration-event-stream/design.md) feature (normalized provider-webhook events on a durable RabbitMQ exchange) ships with its own env vars and a reference consumer container (`run_integration_event_consumer`) that this chart didn't yet expose.

## Scope / behavior
- **Not a default-behavior change.** `services.integration_event_consumer.enabled` defaults to `false` — nothing new deploys unless explicitly turned on.
- The shared `INTEGRATION_EVENT_*` vars land on `app-vars`/`silo-vars` unconditionally, but they're inert until the app code reads them (the Django settings/Silo env already default to the same values if unset), so api/worker/beat-worker behavior doesn't change beyond gaining these keys.
- Silo's `INTEGRATION_EVENT_INGEST_ENABLED` defaults to `"0"` — ingest stays off.

## Testing
- `helm lint charts/plane-enterprise` (via `alpine/helm:3.14.0` in Docker) — 0 failures.
- `helm template ... --set services.integration_event_consumer.enabled=true --set services.silo.enabled=true` — confirmed the new ConfigMap, Deployment, and all `INTEGRATION_EVENT_*` keys render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Integration Event Consumer service for processing integration events through a message queue.
  * Added configurable replicas, resources, scheduling, queue settings, prefetching, and supported providers.
  * Added controls for event ingestion, publishing, retries, cleanup, batching, timeouts, and collection settings.
  * Added conditional configuration with sensible defaults for integration event processing.

* **Chores**
  * Updated the enterprise Helm chart and application versions to 3.6.0 and 3.1.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->