### PR TITLE
release: Plane-EE-v3.1.3

### DIFF
--- a/charts/plane-enterprise/Chart.yaml
+++ b/charts/plane-enterprise/Chart.yaml
@@ -5,8 +5,8 @@ description: Meet Plane. An Enterprise software development tool to manage issue
 
 type: application
 
-version: 3.5.2
-appVersion: "3.1.2"
+version: 3.5.3
+appVersion: "3.1.3"
 
 home: https://plane.so/
 icon: https://plane.so/favicon/favicon-32x32.png

--- a/charts/plane-enterprise/README.md
+++ b/charts/plane-enterprise/README.md
@@ -316,7 +316,7 @@ ingress:
    Copy the format of constants below, paste it on Terminal to start setting environment variables, set values for each variable, and hit ENTER or RETURN.
 
    ```bash
-   PLANE_VERSION=v3.1.2 # or the last released version
+   PLANE_VERSION=v3.1.3 # or the last released version
    DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
    ```
 
@@ -372,7 +372,7 @@ ingress:
 
      Make sure you set the minimum required values as below.
 
-     - `planeVersion: v3.1.2 <or the last released version>`
+     - `planeVersion: v3.1.3 <or the last released version>`
      - `license.licenseDomain: <The domain you have specified to host Plane>`
      - `ingress.enabled: <true | false>`
      - `ingress.ingressClass: <traefik or any other ingress class configured in your cluster>`
@@ -398,7 +398,7 @@ ingress:
 
 | Setting               |      Default      | Required | Description                                                                                                                                                                          |
 | --------------------- | :---------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| planeVersion          |      v3.1.2       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
+| planeVersion          |      v3.1.3       |   Yes    | Specifies the version of Plane to be deployed. Copy this from prime.plane.so.                                                                                                        |
 | license.licenseDomain | plane.example.com |   Yes    | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
 ### Air-gapped Settings

--- a/charts/plane-enterprise/questions.yml
+++ b/charts/plane-enterprise/questions.yml
@@ -27,7 +27,7 @@ questions:
 - variable: planeVersion
   label: Plane Version (Docker Image Tag)
   type: string
-  default: v3.1.2
+  default: v3.1.3
   required: true
   group: "Docker Registry"
   subquestions:

--- a/charts/plane-enterprise/values.yaml
+++ b/charts/plane-enterprise/values.yaml
@@ -1,4 +1,4 @@
-planeVersion: v3.1.2
+planeVersion: v3.1.3
 
 dockerRegistry:
   enabled: false


### PR DESCRIPTION
## Summary
- Bump Plane Enterprise chart `appVersion` from `3.1.2` to `3.1.3` and chart `version` from `3.5.2` to `3.5.3`
- Update `planeVersion` default from `v3.1.2` to `v3.1.3` in `values.yaml`, `questions.yml`, and `README.md`

## Test plan
- [ ] `helm lint charts/plane-enterprise` passes
- [ ] `helm template` renders correctly with new version values
- [ ] Deploy to a staging environment and verify all pods come up with the v3.1.3 images

🧙 Built with [WOZCODE](https://wozcode.com)