### PR TITLE
docs(plane-enterprise): state the OpenShift image requirement as a version

### DIFF
--- a/charts/plane-enterprise/examples/values-openshift.yaml
+++ b/charts/plane-enterprise/examples/values-openshift.yaml
@@ -20,9 +20,9 @@
 # removes it during Helm's coalescing, so the rendered securityContext keeps
 # runAsNonRoot, seccompProfile and the dropped capabilities but carries no UID.
 #
-# REQUIRES the images that grant group 0 write access to their runtime paths
-# (plane-ee #9018). Older images crash under an arbitrary UID — nginx exits with
-# `mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)`.
+# REQUIRES images that grant group 0 write access to their runtime paths, which means
+# planeVersion v3.2.0 or newer. Older images crash under an arbitrary UID — nginx exits
+# with `mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)`.
 # =============================================================================
 
 securityContext:


### PR DESCRIPTION
The OpenShift example told readers the arbitrary-UID support "REQUIRES the images that grant group 0 write access to their runtime paths (plane-ee #9018)".

This is a public repository, so that pull request is not something a reader can open — and a PR number is the wrong unit anyway. Replaced with the version that carries the change:

```diff
-# REQUIRES the images that grant group 0 write access to their runtime paths
-# (plane-ee #9018). Older images crash under an arbitrary UID — nginx exits with
+# REQUIRES images that grant group 0 write access to their runtime paths, which means
+# planeVersion v3.2.0 or newer. Older images crash under an arbitrary UID — nginx exits
 # with `mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)`.
```

v3.2.0 verified as the right bound: the image change is contained in `v3.2.0-rc1` and is absent from `v3.1.2` and `v3.1.3`.

Comment only — no rendered output changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenShift compatibility note to clarify that Plane version 3.2.0 or newer is required for arbitrary-UID execution.
  * Retained the warning that older images may fail due to nginx cache-directory permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->