### PR TITLE
feat(plane-ce): opt-in Stakater Reloader annotation (1.8.0)

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.7.0
+version: 1.8.0
 appVersion: "1.4.1"
 
 home: https://plane.so

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-admin-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.admin) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.admin.replicas | default 1 }}
   selector:

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.api.replicas | default 1}}
   selector:

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-beat-worker-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.beatworker) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.beatworker.replicas | default 1 }}
   selector:

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-live-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.live) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.live.replicas | default 1 }}
   selector:

--- a/charts/plane-ce/templates/workloads/migrator.job.yaml
+++ b/charts/plane-ce/templates/workloads/migrator.job.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-api-migrate-{{ .Release.Revision }}
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.api) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   backoffLimit: 3
   template:

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -31,6 +31,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.minio) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -90,6 +94,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-minio-bucket-{{ .Release.Revision }}
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.minio) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   backoffLimit: 6
   completionMode: NonIndexed

--- a/charts/plane-ce/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/postgres.stateful.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-pgdb-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.postgres) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
@@ -31,6 +31,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-rabbitmq-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.rabbitmq) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/plane-ce/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/redis.stateful.yaml
@@ -29,6 +29,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-redis-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.redis) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-space-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.space) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.space.replicas | default 1 }}
   selector:

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-web-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.web) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.web.replicas | default 1 }}
   selector:

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-worker-wl
   {{- include "plane.labelsAndAnnotations" (dict "context" $ "values" .Values.worker) }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.worker.replicas | default 1 }}
   selector:

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -347,3 +347,17 @@ env:
   default_cluster_domain: cluster.local
 
   api_key_rate_limit: "60/minute"
+
+# ------------------------------------------------------------------
+# Stakater Reloader
+# ------------------------------------------------------------------
+# Adds reloader.stakater.com/auto to every workload, so a rolling restart happens
+# when a Secret or ConfigMap it references changes -- including the Secrets named
+# in external_secrets, which is how a rotated credential reaches a running pod.
+# Without it, whatever manages those Secrets refreshes them on its own schedule and
+# the pods keep the values they started with.
+#
+# Requires Reloader to be installed in the cluster; the chart does not install it.
+reloader:
+  enabled: false
+


### PR DESCRIPTION
**1.7.0 has no reloader flag** — checked the published chart and master: no `reloader` block in `values.yaml`, and no `reloader` string anywhere in `templates/`.

That leaves #285 half-finished in practice. It gave the chart the externalized-secret contract, but nothing restarts the workloads when one of those Secrets changes — so a rotated credential lands in the Kubernetes Secret while the pods keep the value they started with. **The credentials would be out of git and still effectively unrotatable**, which is worse than obviously-unmigrated because it looks done.

Same flag as plane-cloud 4.9.0 (#707), plane-enterprise 3.6.0 (#278) and plane-mcp-server 1.5.0 (#708): `reloader.enabled` annotates every workload with `reloader.stakater.com/auto`, on the **workload** rather than the pod template, which is where Reloader looks.

## Why now

`internal-scripts#172` migrates `community-canary` and `community-latest`, and their secrets are already in AWS (`terraform-scripts#117`). Without this, that migration ships rotation-broken. Their app PR should pin **1.8.0** and set the flag in the same change rather than bumping twice.

## Verification

- **Flag off → 0 lines** different from published 1.7.0 on the default render. Additive.
- **Flag on → 12/12** workloads annotated, checked against both community environments' **real** `values.yaml` rather than chart defaults.
- `helm lint` clean.

## Version

1.7.0 → **1.8.0**, matching the minor bumps the other three charts took for this same change. Note #285's description earmarked 1.8.0 for the discrete-parts / DSN work; that work is still blocked on upstream `makeplane/plane` support, so it takes the next number instead. Worth a glance in case you would rather this be 1.7.1 — it is additive and defaults off, so either is defensible.
