### PR TITLE
feat(plane-ce): extraObjects, so an environment can ship its own ESO manifests (1.8.0)

### DIFF
--- a/charts/plane-ce/Chart.yaml
+++ b/charts/plane-ce/Chart.yaml
@@ -5,7 +5,7 @@ description: Meet Plane. An open-source software development tool to manage issu
 
 type: application
 
-version: 1.7.0
+version: 1.8.0
 appVersion: "1.4.1"
 
 home: https://plane.so

--- a/charts/plane-ce/templates/extra-objects.yaml
+++ b/charts/plane-ce/templates/extra-objects.yaml
@@ -1,0 +1,38 @@
+{{/*
+Arbitrary extra objects, supplied by the operator through values.
+
+The reason this exists: everything a Plane environment needs to STOP holding credentials --
+an ESO SecretStore, the ExternalSecrets that produce the Secrets this chart reads by name --
+is not part of this chart and never should be, but it also has nowhere else to live when the
+release is delivered by a GitOps tool that treats one directory as one unit. Without this,
+those objects need a second bundle purely to exist, and a second bundle is a second thing to
+order correctly.
+
+Rendered with toYaml and NOT tpl, deliberately. The objects people put here are usually
+ExternalSecrets whose `target.template` contains ESO's own {{ }} placeholders; tpl would try
+to evaluate those as Helm expressions and fail, or worse, silently resolve them to empty.
+Values are not templated by Helm, so writing them here passes them through untouched.
+
+Ordering: give an object the standard Helm hook annotations to have it applied before the
+workloads, which is what an ExternalSecret wants -- the chart's Secret references are
+optional: false, so a pod that starts before its Secret exists sits in
+CreateContainerConfigError until it appears.
+
+  extraObjects:
+    - apiVersion: external-secrets.io/v1
+      kind: SecretStore
+      metadata:
+        name: aws-secrets-manager
+        annotations:
+          helm.sh/hook: pre-install,pre-upgrade
+          helm.sh/hook-weight: "-10"
+          helm.sh/hook-delete-policy: before-hook-creation
+      spec: { ... }
+
+Namespace is left to the object: most callers want the release namespace, which is the
+default when it is omitted, and a few legitimately want another.
+*/}}
+{{- range .Values.extraObjects }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -347,3 +347,16 @@ env:
   default_cluster_domain: cluster.local
 
   api_key_rate_limit: "60/minute"
+
+# Arbitrary extra Kubernetes objects rendered as part of this release. Intended for the
+# things that let an environment hold no credentials -- an ESO SecretStore and the
+# ExternalSecrets producing the Secrets referenced by external_secrets.* above -- which
+# belong to the operator rather than to this chart, but have nowhere to live when a GitOps
+# tool treats one directory as one unit.
+#
+# Passed through verbatim (toYaml, not tpl) so that ESO's own {{ }} placeholders inside a
+# target.template survive. Add the standard Helm hook annotations to have an object applied
+# BEFORE the workloads; the Secret references in this chart are optional: false, so a pod
+# that starts before its Secret exists waits in CreateContainerConfigError until it appears.
+extraObjects: []
+


### PR DESCRIPTION
#285 gave this chart the externalized-secret contract but **no way to deliver the objects that produce those Secrets**. A `SecretStore` and the `ExternalSecret`s behind `external_secrets.*` belong to the operator rather than to this chart — but they have nowhere to live when a GitOps tool treats one directory as one unit.

Without this they need a second Fleet bundle purely to exist, and a second bundle is a second thing to order correctly. plane-enterprise already has `extraObjects` for exactly this; this brings plane-ce level.

## The part that is easy to get wrong

Rendered with `toYaml` and **not** `tpl`, matching plane-enterprise. The objects people put here are usually ExternalSecrets whose `target.template` carries **ESO's own `{{ }}` placeholders** — `tpl` would try to evaluate those as Helm expressions and either fail or, worse, silently resolve them to empty.

Verified with a realistic ExternalSecret. In, and out of the render byte-identical:

```yaml
REDIS_URL: 'redis://:{{ .password }}@t-redis.ns.svc.cluster.local:6379/'
```

## Ordering

Left to the standard Helm hook annotations, which is what an ExternalSecret wants:

```yaml
extraObjects:
  - apiVersion: external-secrets.io/v1
    kind: SecretStore
    metadata:
      annotations:
        helm.sh/hook: pre-install,pre-upgrade
        helm.sh/hook-weight: "-10"
        helm.sh/hook-delete-policy: before-hook-creation
```

This chart's Secret references are `optional: false`, so a pod that starts before its Secret exists waits in `CreateContainerConfigError` rather than starting without a credential — which is the behaviour you want, and why the hook weights matter.

## Verification

- **Additive**: with `extraObjects` empty (the default), the render is **0 lines** different from published 1.7.0.
- `extraObjects` renders, hook annotations intact, ESO placeholders untouched.
- `helm lint` clean.

## Why it needs to land

`internal-scripts` is migrating `community-canary` and `community-latest` off committed credentials — secrets already in AWS (`terraform-scripts#117`), IAM in `internal-scripts#172`. Their ESO manifests need somewhere to live, and this is it.

Note this is **only** `extraObjects` — no Reloader annotation. That stays out of the public charts and is set per workload from the deployment repo via `services.<name>.annotations`, which already reaches the workload resource.
